### PR TITLE
Clean up dead nonlinear solver code

### DIFF
--- a/src/loadcase/nonlinear_static.cpp
+++ b/src/loadcase/nonlinear_static.cpp
@@ -237,22 +237,15 @@ void NonlinearStatic::run() {
     logging::error(model->_data->positions_reference != nullptr,
         "NonlinearStatic: positions_reference field not initialized");
 
-    // Preserve the caller-visible position field and start the nonlinear step
-    // from the undeformed reference configuration
     const model::Field original_positions  = *model->_data->positions;
     const model::Field reference_positions = *model->_data->positions_reference;
     *model->_data->positions = reference_positions;
 
-    // Bind element sections and initialize step-local element geometry/state caches
     model->assign_sections();
     model->step_begin();
 
-    // Own material history buffers and coordinate all contact trial states for
-    // the duration of this nonlinear solution.
     tools::NonlinearStateManager nonlinear_state(*model);
 
-    // Build active DOFs, external loading and constraint groups shared by all
-    // nonlinear evaluations
     auto active_dof_idx_mat = Timer::measure(
         [&]() { return model->build_unconstrained_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
@@ -273,17 +266,12 @@ void NonlinearStatic::run() {
         "building constraints"
     );
 
-    // Report the semantic constraint groups before flattening them for algebraic use
     report_constraint_groups(groups);
-
-    // Flatten semantic groups into the complete equation set used by the transformer
     auto equations = groups.flatten();
 
-    // Cache global dimensions required by reduced-vector and nodal-field assembly
     const Index n_active  = active_dof_idx_mat.maxCoeff() + 1;
     const Index max_nodes = static_cast<Index>(model->_data->max_nodes);
 
-    // Construct the affine null-space transformation for prescribed and coupled DOFs
     auto transformer = Timer::measure(
         [&]() {
             ConstraintTransformer::Options options;
@@ -339,9 +327,6 @@ void NonlinearStatic::run() {
 
     update_positions();
 
-    model::Field final_internal{"INTERNAL_FORCES", model::FieldDomain::NODE, max_nodes, 6};
-    final_internal.set_zero();
-
     Precision load_factor = Precision(0);
 
     logging::info(true, "");
@@ -352,8 +337,6 @@ void NonlinearStatic::run() {
     logging::info(true, " inc iter      lambda        rel_res          du_norm   ls   asm_ms solve_ms");
     logging::info(true, "----------------------------------------------------------------------------");
 
-    // Stream converged increment frames as they become available. This keeps
-    // the accepted path in the result file even if a later increment fails.
     writer->add_loadcase(id, io::writer::WriterStepType::Static);
 
     Index last_converged_increment = 0;
@@ -363,16 +346,9 @@ void NonlinearStatic::run() {
                               DynamicVector&       residual,
                               SparseMatrix&        tangent,
                               SparseMatrix*        full_tangent) {
-        // Every independent nonlinear evaluation starts from the material
-        // history of the last accepted physical increment.
         nonlinear_state.reset_material_state();
 
-        // Evaluate the supplied solver state without modifying q_total. This is
-        // essential because line-search trial states must not modify the actual
-        // Newton iterate.
-        const DynamicVector u_evaluation =
-            recover_total_displacement(q, lambda);
-
+        const DynamicVector u_evaluation = recover_total_displacement(q, lambda);
         const model::Field displacement_evaluation =
             mattools::expand_vec_to_mat(active_dof_idx_mat, u_evaluation);
 
@@ -404,7 +380,6 @@ void NonlinearStatic::run() {
             if (logging_was_enabled) {
                 logging::enable();
             }
-
             throw;
         }
 
@@ -413,17 +388,11 @@ void NonlinearStatic::run() {
         }
 
         if (regularize_zero_stiffness_rows) {
-            regularise_stiffness(
-                Kt,
-                zero_stiffness_regularization_alpha
-            );
+            regularise_stiffness(Kt, zero_stiffness_regularization_alpha);
         }
 
         const DynamicVector internal_force =
-            mattools::reduce_mat_to_vec(
-                active_dof_idx_mat,
-                internal_mat
-            );
+            mattools::reduce_mat_to_vec(active_dof_idx_mat, internal_mat);
 
         const DynamicVector external_force = lambda * f_total;
         const DynamicVector full_residual  = external_force - internal_force;
@@ -436,40 +405,23 @@ void NonlinearStatic::run() {
 
         tangent = transformer->assemble_system_matrix(Kt);
 
-        final_internal = internal_mat;
-
-        logging::error(
-            residual.allFinite(),
-            "Reduced residual contains NaN/Inf entries"
-        );
+        logging::error(residual.allFinite(),
+            "Reduced residual contains NaN/Inf entries");
     };
 
     auto evaluate = [&](const DynamicVector& q,
                         Precision            lambda,
                         DynamicVector&       residual,
                         SparseMatrix&        tangent) {
-        assemble_state(
-            q,
-            lambda,
-            residual,
-            tangent,
-            nullptr
-        );
+        assemble_state(q, lambda, residual, tangent, nullptr);
     };
 
     auto evaluate_residual = [&](const DynamicVector& q,
                                  Precision            lambda,
                                  DynamicVector&       residual) {
-        // Line-search candidates are independent material evaluations of the
-        // same physical increment and therefore restart from committed history.
         nonlinear_state.reset_material_state();
 
-        // Evaluate the same nonlinear residual as the full tangent assembly,
-        // but avoid constructing the material and geometric element tangents.
-        // Line-search acceptance only uses the projected residual norm.
-        const DynamicVector u_evaluation =
-            recover_total_displacement(q, lambda);
-
+        const DynamicVector u_evaluation = recover_total_displacement(q, lambda);
         const model::Field displacement_evaluation =
             mattools::expand_vec_to_mat(active_dof_idx_mat, u_evaluation);
 
@@ -499,7 +451,6 @@ void NonlinearStatic::run() {
             if (logging_was_enabled) {
                 logging::enable();
             }
-
             throw;
         }
 
@@ -508,23 +459,18 @@ void NonlinearStatic::run() {
         }
 
         const DynamicVector internal_force =
-            mattools::reduce_mat_to_vec(
-                active_dof_idx_mat,
-                internal_mat
-            );
+            mattools::reduce_mat_to_vec(active_dof_idx_mat, internal_mat);
 
         const DynamicVector external_force = lambda * f_total;
         const DynamicVector full_residual  = external_force - internal_force;
 
         transformer->project_vector(full_residual, residual);
 
-        final_internal = internal_mat;
-
         logging::error(residual.allFinite(),
             "Reduced residual contains NaN/Inf entries");
     };
 
-    auto linear_solve = [&](const SparseMatrix&  tangent,
+    auto linear_solve = [&](const SparseMatrix& tangent,
                             const DynamicVector& rhs) {
         SparseMatrix matrix = tangent;
 
@@ -554,31 +500,12 @@ void NonlinearStatic::run() {
             return;
         }
 
-        /*
-         * Assemble the tangent at the last accepted equilibrium state. For
-         *
-         *     u(lambda, q) = lambda * u_p + T q
-         *
-         * the equilibrium-path tangent follows from
-         *
-         *     T^T K_t T dq/dlambda = T^T (f - K_t u_p).
-         *
-         * ConstraintTransformer::assemble_system_rhs() already evaluates the
-         * right-hand side T^T (f - K_t u_p), so the same predictor handles
-         * force loading, prescribed displacements and arbitrary mixtures.
-         */
         DynamicVector accepted_residual;
         SparseMatrix  accepted_tangent;
         SparseMatrix  accepted_full_tangent;
 
-        /*
-         * The outer increment trial is deliberately still unfrozen here. The
-         * predictor tangent is evaluated at the last accepted configuration,
-         * but it must not select and freeze the partners that Newton will use
-         * at the predicted target configuration. A nested frozen trial makes
-         * this assembly completely state-neutral and is always rolled back.
-         */
-        nonlinear_state.begin_contact_frozen_trial();
+        // The predictor assembly is a nested state-neutral contact trial.
+        nonlinear_state.begin_contact_trial();
 
         try {
             assemble_state(
@@ -596,21 +523,13 @@ void NonlinearStatic::run() {
         nonlinear_state.rollback_contact_trial();
 
         const DynamicVector predictor_rhs =
-            transformer->assemble_system_rhs(
-                accepted_full_tangent,
-                f_total
-            );
+            transformer->assemble_system_rhs(accepted_full_tangent, f_total);
 
-        const DynamicVector dq_dlambda =
-            linear_solve(
-                accepted_tangent,
-                predictor_rhs
-            );
-
+        const DynamicVector dq_dlambda = linear_solve(accepted_tangent, predictor_rhs);
         q += (target_lambda - lambda) * dq_dlambda;
     };
 
-    auto matrix_solve = [&](const SparseMatrix&  tangent,
+    auto matrix_solve = [&](const SparseMatrix& tangent,
                             const DynamicMatrix& rhs) {
         SparseMatrix matrix = tangent;
 
@@ -642,14 +561,12 @@ void NonlinearStatic::run() {
     auto residual_norm = [&](const DynamicVector& residual,
                              Precision            lambda) {
         const DynamicVector reduced_external = lambda * reduced_total_load;
-
         return calculate_relative_residual(residual, reduced_external);
     };
 
     auto correction_norm = [&](const DynamicVector& q,
                                const DynamicVector& dq) {
         (void) q;
-
         const DynamicVector du = transformer->recover_increment(dq);
         return du.norm();
     };
@@ -659,14 +576,9 @@ void NonlinearStatic::run() {
                             Precision lambda,
                             Precision residual_norm,
                             Precision correction_norm,
-                            Precision convergence_order,
                             Index     line_search_iterations,
                             Time      assembly_ms,
-                            Time      solve_ms,
-                            bool      converged) {
-        (void) convergence_order;
-        (void) converged;
-
+                            Time      solve_ms) {
         logging::info(
             true,
             std::setw(4), increment,
@@ -711,59 +623,50 @@ void NonlinearStatic::run() {
             lambda
         );
 
-        model::Field lambda_field{"LAMBDA_" + std::to_string(increment), model::FieldDomain::UNKNOWN, 1, 1};
+        model::Field lambda_field{
+            "LAMBDA_" + std::to_string(increment),
+            model::FieldDomain::UNKNOWN,
+            1,
+            1
+        };
         lambda_field(0) = lambda;
-
         writer->write_field(lambda_field, lambda_field.name, nullptr);
     };
 
-    // Start a complete increment attempt. Material history is reset to the last
-    // accepted increment and contact may update partner ownership once before
-    // freezing the discrete contact problem for Newton.
     auto begin_increment_trial = [&]() {
         nonlinear_state.reset_material_state();
-        nonlinear_state.begin_contact_update_trial();
+        nonlinear_state.begin_contact_trial();
     };
 
-    // Accept the converged material history and the outer contact trial.
     auto commit_increment_trial = [&]() {
         nonlinear_state.commit_contact_trial();
         nonlinear_state.commit_material_state();
     };
 
-    // Reject the complete increment attempt and restore both state subsystems to
-    // the last accepted physical increment.
     auto rollback_increment_trial = [&]() {
         nonlinear_state.rollback_contact_trial();
         nonlinear_state.reset_material_state();
     };
 
-    // Open a temporary contact trial for one line-search candidate. Material
-    // history is reset by evaluate_residual() immediately before assembly.
     auto begin_line_search_trial = [&]() {
-        nonlinear_state.begin_contact_frozen_trial();
+        nonlinear_state.begin_contact_trial();
     };
 
-    // Promote the accepted candidate's contact geometry to its parent trial
     auto commit_line_search_trial = [&]() {
         nonlinear_state.commit_contact_trial();
     };
 
-    // Discard a rejected candidate without changing its parent contact state
     auto rollback_line_search_trial = [&]() {
         nonlinear_state.rollback_contact_trial();
     };
 
-    // Refresh discontinuous contact state after Newton convergence. The update
-    // trial evaluates the converged geometry with partner updates enabled once;
-    // a changed partner signature or multiplier requests another Newton solve.
     auto update_active_set = [&](const DynamicVector& q,
                                  Precision            lambda) {
         if (model->_data->contacts.empty()) {
             return true;
         }
 
-        nonlinear_state.begin_contact_update_trial();
+        nonlinear_state.begin_contact_trial();
 
         try {
             DynamicVector active_set_residual;
@@ -789,17 +692,9 @@ void NonlinearStatic::run() {
     bool        converged      = false;
     std::string failure_reason = "NONE";
 
-    // Use the nonlinear controls exactly as configured. The trial callbacks
-    // below manage stateful nonlinear subsystems without changing increment or
-    // iteration limits based on which subsystem is present.
-    const Index configured_max_iterations =
-        static_cast<Index>(max_iterations);
-
-    const Index configured_max_increments =
-        static_cast<Index>(max_increments);
-
-    const Index configured_slow_iterations =
-        static_cast<Index>(slow_iterations);
+    const Index configured_max_iterations = static_cast<Index>(max_iterations);
+    const Index configured_max_increments = static_cast<Index>(max_increments);
+    const Index configured_slow_iterations = static_cast<Index>(slow_iterations);
 
     if (control == NonlinearControl::LoadControl) {
         tools::LoadControl load_control;
@@ -861,12 +756,7 @@ void NonlinearStatic::run() {
         arc_length_control.begin_increment_trial    = begin_increment_trial;
         arc_length_control.commit_increment_trial   = commit_increment_trial;
         arc_length_control.rollback_increment_trial = rollback_increment_trial;
-
-        arc_length_control.begin_line_search_trial    = begin_line_search_trial;
-        arc_length_control.commit_line_search_trial   = commit_line_search_trial;
-        arc_length_control.rollback_line_search_trial = rollback_line_search_trial;
-
-        arc_length_control.update_active_set = update_active_set;
+        arc_length_control.update_active_set        = update_active_set;
 
         converged = arc_length_control.solve(
             q_total,
@@ -878,8 +768,7 @@ void NonlinearStatic::run() {
             residual_norm,
             correction_norm,
             on_iteration,
-            on_increment,
-            evaluate_residual
+            on_increment
         );
 
         failure_reason = arc_length_control.failure_reason();
@@ -888,28 +777,28 @@ void NonlinearStatic::run() {
     logging::error(converged,
         "NONLINEARSTATIC failed: ", failure_reason);
 
-    // Restore the accepted configuration before independent final result evaluations
     update_positions();
 
-    // Each postprocessing path starts from committed material history because
-    // result recovery may call an in-place constitutive model
     nonlinear_state.reset_material_state();
     auto [final_stress, final_strain] = Timer::measure(
         [&]() { return model->compute_stress_nodal(displacement, true); },
         "computing final nonlinear nodal stress/strain"
     );
 
-    // Top/bottom shell recovery is independent of the preceding nodal recovery
     nonlinear_state.reset_material_state();
     auto [final_stress_top, final_stress_bot] = Timer::measure(
         [&]() { return model->compute_stress_top_bot(displacement, true); },
         "computing final nonlinear top/bottom stress"
     );
 
-    final_internal = model::NodeData{"INTERNAL_FORCES", model::FieldDomain::NODE, max_nodes, 6};
+    model::NodeData final_internal{
+        "INTERNAL_FORCES",
+        model::FieldDomain::NODE,
+        max_nodes,
+        6
+    };
     final_internal.set_zero();
 
-    // Reassemble the final tangent and matching internal force from committed history
     nonlinear_state.reset_material_state();
     auto final_Kt = Timer::measure(
         [&]() {
@@ -935,7 +824,7 @@ void NonlinearStatic::run() {
 
     auto global_load_final = global_load_total;
     global_load_final *= load_factor;
-    auto reaction_full     = subtract_field(
+    auto reaction_full = subtract_field(
         final_internal,
         global_load_final,
         "REACTION_FORCES_RAW"
@@ -989,7 +878,6 @@ void NonlinearStatic::run() {
     writer->write_field(final_internal   , "INTERNAL_FORCES" + suffix, model->_data.get(), load_factor);
     writer->write_field(reaction_masked  , "REACTION_FORCES" + suffix, model->_data.get(), load_factor);
 
-    // Restore the caller-visible model configuration and release step-local caches
     *model->_data->positions = original_positions;
     model->step_end();
 }

--- a/src/loadcase/nonlinear_static.cpp
+++ b/src/loadcase/nonlinear_static.cpp
@@ -237,15 +237,22 @@ void NonlinearStatic::run() {
     logging::error(model->_data->positions_reference != nullptr,
         "NonlinearStatic: positions_reference field not initialized");
 
+    // Preserve the caller-visible position field and start the nonlinear step
+    // from the undeformed reference configuration
     const model::Field original_positions  = *model->_data->positions;
     const model::Field reference_positions = *model->_data->positions_reference;
     *model->_data->positions = reference_positions;
 
+    // Bind element sections and initialize step-local element geometry/state caches
     model->assign_sections();
     model->step_begin();
 
+    // Own material history buffers and coordinate all contact trial states for
+    // the duration of this nonlinear solution.
     tools::NonlinearStateManager nonlinear_state(*model);
 
+    // Build active DOFs, external loading and constraint groups shared by all
+    // nonlinear evaluations
     auto active_dof_idx_mat = Timer::measure(
         [&]() { return model->build_unconstrained_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
@@ -266,12 +273,17 @@ void NonlinearStatic::run() {
         "building constraints"
     );
 
+    // Report the semantic constraint groups before flattening them for algebraic use
     report_constraint_groups(groups);
+
+    // Flatten semantic groups into the complete equation set used by the transformer
     auto equations = groups.flatten();
 
+    // Cache global dimensions required by reduced-vector and nodal-field assembly
     const Index n_active  = active_dof_idx_mat.maxCoeff() + 1;
     const Index max_nodes = static_cast<Index>(model->_data->max_nodes);
 
+    // Construct the affine null-space transformation for prescribed and coupled DOFs
     auto transformer = Timer::measure(
         [&]() {
             ConstraintTransformer::Options options;
@@ -337,6 +349,8 @@ void NonlinearStatic::run() {
     logging::info(true, " inc iter      lambda        rel_res          du_norm   ls   asm_ms solve_ms");
     logging::info(true, "----------------------------------------------------------------------------");
 
+    // Stream converged increment frames as they become available. This keeps
+    // the accepted path in the result file even if a later increment fails.
     writer->add_loadcase(id, io::writer::WriterStepType::Static);
 
     Index last_converged_increment = 0;
@@ -346,9 +360,16 @@ void NonlinearStatic::run() {
                               DynamicVector&       residual,
                               SparseMatrix&        tangent,
                               SparseMatrix*        full_tangent) {
+        // Every independent nonlinear evaluation starts from the material
+        // history of the last accepted physical increment.
         nonlinear_state.reset_material_state();
 
-        const DynamicVector u_evaluation = recover_total_displacement(q, lambda);
+        // Evaluate the supplied solver state without modifying q_total. This is
+        // essential because line-search trial states must not modify the actual
+        // Newton iterate.
+        const DynamicVector u_evaluation =
+            recover_total_displacement(q, lambda);
+
         const model::Field displacement_evaluation =
             mattools::expand_vec_to_mat(active_dof_idx_mat, u_evaluation);
 
@@ -380,6 +401,7 @@ void NonlinearStatic::run() {
             if (logging_was_enabled) {
                 logging::enable();
             }
+
             throw;
         }
 
@@ -388,11 +410,17 @@ void NonlinearStatic::run() {
         }
 
         if (regularize_zero_stiffness_rows) {
-            regularise_stiffness(Kt, zero_stiffness_regularization_alpha);
+            regularise_stiffness(
+                Kt,
+                zero_stiffness_regularization_alpha
+            );
         }
 
         const DynamicVector internal_force =
-            mattools::reduce_mat_to_vec(active_dof_idx_mat, internal_mat);
+            mattools::reduce_mat_to_vec(
+                active_dof_idx_mat,
+                internal_mat
+            );
 
         const DynamicVector external_force = lambda * f_total;
         const DynamicVector full_residual  = external_force - internal_force;
@@ -405,23 +433,38 @@ void NonlinearStatic::run() {
 
         tangent = transformer->assemble_system_matrix(Kt);
 
-        logging::error(residual.allFinite(),
-            "Reduced residual contains NaN/Inf entries");
+        logging::error(
+            residual.allFinite(),
+            "Reduced residual contains NaN/Inf entries"
+        );
     };
 
     auto evaluate = [&](const DynamicVector& q,
                         Precision            lambda,
                         DynamicVector&       residual,
                         SparseMatrix&        tangent) {
-        assemble_state(q, lambda, residual, tangent, nullptr);
+        assemble_state(
+            q,
+            lambda,
+            residual,
+            tangent,
+            nullptr
+        );
     };
 
     auto evaluate_residual = [&](const DynamicVector& q,
                                  Precision            lambda,
                                  DynamicVector&       residual) {
+        // Line-search candidates are independent material evaluations of the
+        // same physical increment and therefore restart from committed history.
         nonlinear_state.reset_material_state();
 
-        const DynamicVector u_evaluation = recover_total_displacement(q, lambda);
+        // Evaluate the same nonlinear residual as the full tangent assembly,
+        // but avoid constructing the material and geometric element tangents.
+        // Line-search acceptance only uses the projected residual norm.
+        const DynamicVector u_evaluation =
+            recover_total_displacement(q, lambda);
+
         const model::Field displacement_evaluation =
             mattools::expand_vec_to_mat(active_dof_idx_mat, u_evaluation);
 
@@ -451,6 +494,7 @@ void NonlinearStatic::run() {
             if (logging_was_enabled) {
                 logging::enable();
             }
+
             throw;
         }
 
@@ -459,7 +503,10 @@ void NonlinearStatic::run() {
         }
 
         const DynamicVector internal_force =
-            mattools::reduce_mat_to_vec(active_dof_idx_mat, internal_mat);
+            mattools::reduce_mat_to_vec(
+                active_dof_idx_mat,
+                internal_mat
+            );
 
         const DynamicVector external_force = lambda * f_total;
         const DynamicVector full_residual  = external_force - internal_force;
@@ -470,7 +517,7 @@ void NonlinearStatic::run() {
             "Reduced residual contains NaN/Inf entries");
     };
 
-    auto linear_solve = [&](const SparseMatrix& tangent,
+    auto linear_solve = [&](const SparseMatrix&  tangent,
                             const DynamicVector& rhs) {
         SparseMatrix matrix = tangent;
 
@@ -500,11 +547,26 @@ void NonlinearStatic::run() {
             return;
         }
 
+        /*
+         * Assemble the tangent at the last accepted equilibrium state. For
+         *
+         *     u(lambda, q) = lambda * u_p + T q
+         *
+         * the equilibrium-path tangent follows from
+         *
+         *     T^T K_t T dq/dlambda = T^T (f - K_t u_p).
+         *
+         * ConstraintTransformer::assemble_system_rhs() already evaluates the
+         * right-hand side T^T (f - K_t u_p), so the same predictor handles
+         * force loading, prescribed displacements and arbitrary mixtures.
+         */
         DynamicVector accepted_residual;
         SparseMatrix  accepted_tangent;
         SparseMatrix  accepted_full_tangent;
 
-        // The predictor assembly is a nested state-neutral contact trial.
+        // The predictor assembly is a nested state-neutral contact trial. Contact
+        // geometry is reconstructed from the supplied positions and is not part
+        // of the transactional state.
         nonlinear_state.begin_contact_trial();
 
         try {
@@ -523,13 +585,21 @@ void NonlinearStatic::run() {
         nonlinear_state.rollback_contact_trial();
 
         const DynamicVector predictor_rhs =
-            transformer->assemble_system_rhs(accepted_full_tangent, f_total);
+            transformer->assemble_system_rhs(
+                accepted_full_tangent,
+                f_total
+            );
 
-        const DynamicVector dq_dlambda = linear_solve(accepted_tangent, predictor_rhs);
+        const DynamicVector dq_dlambda =
+            linear_solve(
+                accepted_tangent,
+                predictor_rhs
+            );
+
         q += (target_lambda - lambda) * dq_dlambda;
     };
 
-    auto matrix_solve = [&](const SparseMatrix& tangent,
+    auto matrix_solve = [&](const SparseMatrix&  tangent,
                             const DynamicMatrix& rhs) {
         SparseMatrix matrix = tangent;
 
@@ -561,12 +631,14 @@ void NonlinearStatic::run() {
     auto residual_norm = [&](const DynamicVector& residual,
                              Precision            lambda) {
         const DynamicVector reduced_external = lambda * reduced_total_load;
+
         return calculate_relative_residual(residual, reduced_external);
     };
 
     auto correction_norm = [&](const DynamicVector& q,
                                const DynamicVector& dq) {
         (void) q;
+
         const DynamicVector du = transformer->recover_increment(dq);
         return du.norm();
     };
@@ -623,43 +695,51 @@ void NonlinearStatic::run() {
             lambda
         );
 
-        model::Field lambda_field{
-            "LAMBDA_" + std::to_string(increment),
-            model::FieldDomain::UNKNOWN,
-            1,
-            1
-        };
+        model::Field lambda_field{"LAMBDA_" + std::to_string(increment), model::FieldDomain::UNKNOWN, 1, 1};
         lambda_field(0) = lambda;
+
         writer->write_field(lambda_field, lambda_field.name, nullptr);
     };
 
+    // Start a complete increment attempt. Material history is reset to the last
+    // accepted increment and contact multiplier/evaluation history is copied to
+    // a nested trial.
     auto begin_increment_trial = [&]() {
         nonlinear_state.reset_material_state();
         nonlinear_state.begin_contact_trial();
     };
 
+    // Accept the converged material history and the outer contact trial.
     auto commit_increment_trial = [&]() {
         nonlinear_state.commit_contact_trial();
         nonlinear_state.commit_material_state();
     };
 
+    // Reject the complete increment attempt and restore both state subsystems to
+    // the last accepted physical increment.
     auto rollback_increment_trial = [&]() {
         nonlinear_state.rollback_contact_trial();
         nonlinear_state.reset_material_state();
     };
 
+    // Open a temporary contact trial for one line-search candidate. Material
+    // history is reset by evaluate_residual() immediately before assembly.
     auto begin_line_search_trial = [&]() {
         nonlinear_state.begin_contact_trial();
     };
 
+    // Promote the accepted candidate's contact state to its parent trial.
     auto commit_line_search_trial = [&]() {
         nonlinear_state.commit_contact_trial();
     };
 
+    // Discard a rejected candidate without changing its parent contact state.
     auto rollback_line_search_trial = [&]() {
         nonlinear_state.rollback_contact_trial();
     };
 
+    // Refresh augmented-Lagrange contact state after Newton convergence. A
+    // multiplier change requests another Newton solve at the same load factor.
     auto update_active_set = [&](const DynamicVector& q,
                                  Precision            lambda) {
         if (model->_data->contacts.empty()) {
@@ -692,9 +772,17 @@ void NonlinearStatic::run() {
     bool        converged      = false;
     std::string failure_reason = "NONE";
 
-    const Index configured_max_iterations = static_cast<Index>(max_iterations);
-    const Index configured_max_increments = static_cast<Index>(max_increments);
-    const Index configured_slow_iterations = static_cast<Index>(slow_iterations);
+    // Use the nonlinear controls exactly as configured. The trial callbacks
+    // below manage stateful nonlinear subsystems without changing increment or
+    // iteration limits based on which subsystem is present.
+    const Index configured_max_iterations =
+        static_cast<Index>(max_iterations);
+
+    const Index configured_max_increments =
+        static_cast<Index>(max_increments);
+
+    const Index configured_slow_iterations =
+        static_cast<Index>(slow_iterations);
 
     if (control == NonlinearControl::LoadControl) {
         tools::LoadControl load_control;
@@ -756,7 +844,8 @@ void NonlinearStatic::run() {
         arc_length_control.begin_increment_trial    = begin_increment_trial;
         arc_length_control.commit_increment_trial   = commit_increment_trial;
         arc_length_control.rollback_increment_trial = rollback_increment_trial;
-        arc_length_control.update_active_set        = update_active_set;
+
+        arc_length_control.update_active_set = update_active_set;
 
         converged = arc_length_control.solve(
             q_total,
@@ -777,28 +866,28 @@ void NonlinearStatic::run() {
     logging::error(converged,
         "NONLINEARSTATIC failed: ", failure_reason);
 
+    // Restore the accepted configuration before independent final result evaluations
     update_positions();
 
+    // Each postprocessing path starts from committed material history because
+    // result recovery may call an in-place constitutive model
     nonlinear_state.reset_material_state();
     auto [final_stress, final_strain] = Timer::measure(
         [&]() { return model->compute_stress_nodal(displacement, true); },
         "computing final nonlinear nodal stress/strain"
     );
 
+    // Top/bottom shell recovery is independent of the preceding nodal recovery
     nonlinear_state.reset_material_state();
     auto [final_stress_top, final_stress_bot] = Timer::measure(
         [&]() { return model->compute_stress_top_bot(displacement, true); },
         "computing final nonlinear top/bottom stress"
     );
 
-    model::NodeData final_internal{
-        "INTERNAL_FORCES",
-        model::FieldDomain::NODE,
-        max_nodes,
-        6
-    };
+    model::NodeData final_internal{"INTERNAL_FORCES", model::FieldDomain::NODE, max_nodes, 6};
     final_internal.set_zero();
 
+    // Reassemble the final tangent and matching internal force from committed history
     nonlinear_state.reset_material_state();
     auto final_Kt = Timer::measure(
         [&]() {
@@ -824,7 +913,7 @@ void NonlinearStatic::run() {
 
     auto global_load_final = global_load_total;
     global_load_final *= load_factor;
-    auto reaction_full = subtract_field(
+    auto reaction_full     = subtract_field(
         final_internal,
         global_load_final,
         "REACTION_FORCES_RAW"
@@ -878,6 +967,7 @@ void NonlinearStatic::run() {
     writer->write_field(final_internal   , "INTERNAL_FORCES" + suffix, model->_data.get(), load_factor);
     writer->write_field(reaction_masked  , "REACTION_FORCES" + suffix, model->_data.get(), load_factor);
 
+    // Restore the caller-visible model configuration and release step-local caches
     *model->_data->positions = original_positions;
     model->step_end();
 }

--- a/src/loadcase/tools/arc_length_control.cpp
+++ b/src/loadcase/tools/arc_length_control.cpp
@@ -1,20 +1,6 @@
 /**
  * @file arc_length_control.cpp
- * @brief Implements arc-length control for nonlinear equilibrium paths.
- *
- * The implementation follows nonlinear static equilibrium paths by solving the
- * finite-element residual together with a scalar arc-length constraint. The path
- * radius is adapted between accepted increments, while each attempted increment
- * may be rolled back and retried when Newton convergence or final-load
- * adjustment fails.
- *
- * All finite-element-specific work is delegated to callbacks supplied by the
- * owning load case. This file only handles the reduced path-following algorithm,
- * augmented Newton system, cutback/growth decisions, active-set restarts and
- * state transaction wiring for nonlinear subsystems.
- *
- * @see ArcLengthControl
- * @see NewtonSolver
+ * @brief Implements nonlinear arc-length control.
  */
 
 #include "arc_length_control.h"
@@ -36,47 +22,6 @@ constexpr Index maximum_active_set_updates = 8;
 
 } // namespace
 
-/**
- * Solves the nonlinear equilibrium path with an arc-length constraint.
- *
- * Each attempted increment starts from the last accepted reduced state `q` and
- * load factor `lambda`. The first tangent predictor determines a load-direction
- * correction and the current radius. Subsequent Newton iterations solve an
- * augmented system containing both the reduced equilibrium residual and the
- * spherical path constraint
- *
- *     ||Delta q||^2 + psi^2 load_scale^2 Delta lambda^2 = radius^2.
- *
- * Increment trial callbacks wrap the complete attempted path increment. They are
- * committed only after the increment is accepted and rolled back for cutbacks,
- * failed Newton solves, failed final-load adjustments or callback exceptions.
- *
- * The current arc-length implementation disables Newton line search because the
- * generic line search scales only the explicit state vector while arc-length
- * corrections also contain an implicit load-factor correction.
- *
- * After a converged augmented Newton solve, `update_active_set` may update
- * discontinuous nonlinear state at the converged configuration. A reported
- * change restarts Newton on the same path increment using the new state.
- *
- * @param q Reduced nonlinear unknown vector. On success it contains the final
- *          accepted state. On failure it is restored to the last accepted state.
- * @param lambda Load factor associated with `q`.
- * @param reference_load Reduced reference load vector used by the arc-length
- *                       predictor and augmented Newton system.
- * @param evaluate Residual and tangent assembly at a supplied `q` and load
- *                 factor.
- * @param linear_solve Linearized solve with one right-hand side.
- * @param matrix_solve Linearized solve for the augmented system.
- * @param residual_norm Problem-specific equilibrium-residual measure.
- * @param correction_norm Problem-specific correction-size measure.
- * @param on_iteration Optional per-Newton-iteration reporting callback.
- * @param on_increment Optional accepted-increment callback for result writing.
- * @param evaluate_residual Reserved residual-only callback; currently unused
- *                          because arc-length line search is disabled.
- *
- * @return `true` when the path reaches load factor one, otherwise `false`.
- */
 bool ArcLengthControl::solve(
     DynamicVector&           q,
     Precision&               lambda,
@@ -87,11 +32,8 @@ bool ArcLengthControl::solve(
     const ResidualNorm&      residual_norm,
     const CorrectionNorm&    correction_norm,
     const IterationCallback& on_iteration,
-    const IncrementCallback& on_increment,
-    const EvaluateResidual&  evaluate_residual
+    const IncrementCallback& on_increment
 ) {
-    (void) evaluate_residual;
-
     logging::error(maximum_increments > 0,
         "ArcLengthControl requires maximum_increments > 0");
     logging::error(maximum_iterations > 0,
@@ -132,7 +74,6 @@ bool ArcLengthControl::solve(
         "ArcLengthControl requires a correction norm callback");
 
     reset_state_();
-
     previous_delta_q_ = DynamicVector::Zero(q.size());
 
     Index cutback_count = 0;
@@ -154,8 +95,6 @@ bool ArcLengthControl::solve(
         std::string attempt_error_message;
         Index       active_set_updates     = 0;
 
-        // Treat analysis failures inside this attempted increment like Newton
-        // non-convergence so adaptive arc-length control can reduce the radius.
         try {
             if (begin_increment_trial) {
                 begin_increment_trial();
@@ -164,17 +103,9 @@ bool ArcLengthControl::solve(
             DynamicVector predictor_residual;
             SparseMatrix  predictor_tangent;
 
-            evaluate(
-                q_accepted_,
-                lambda_accepted_,
-                predictor_residual,
-                predictor_tangent
-            );
+            evaluate(q_accepted_, lambda_accepted_, predictor_residual, predictor_tangent);
 
-            DynamicVector dq_load = linear_solve(
-                predictor_tangent,
-                reference_load
-            );
+            DynamicVector dq_load = linear_solve(predictor_tangent, reference_load);
 
             logging::error(dq_load.allFinite(),
                 "ArcLengthControl: predictor contains NaN/Inf entries");
@@ -188,14 +119,11 @@ bool ArcLengthControl::solve(
 
             if (radius_scale_ <= Precision(0)) {
                 load_scale2_  = current_load_scale2;
-                radius_scale_ = std::sqrt(
-                    current_load_scale2 + psi2 * load_scale2_
-                );
+                radius_scale_ = std::sqrt(current_load_scale2 + psi2 * load_scale2_);
             }
 
-            const Precision predictor_norm = std::sqrt(
-                current_load_scale2 + psi2 * load_scale2_
-            );
+            const Precision predictor_norm =
+                std::sqrt(current_load_scale2 + psi2 * load_scale2_);
 
             Precision path_sign = Precision(1);
 
@@ -209,9 +137,7 @@ bool ArcLengthControl::solve(
 
             arc_radius_ = increment_ * radius_scale_;
 
-            Precision predictor_delta_lambda =
-                path_sign * arc_radius_ / predictor_norm;
-
+            Precision predictor_delta_lambda = path_sign * arc_radius_ / predictor_norm;
             const Precision remaining_delta_lambda = Precision(1) - lambda_accepted_;
 
             if (path_sign > Precision(0) &&
@@ -270,7 +196,6 @@ bool ArcLengthControl::solve(
                             if (reference_load(i) != Precision(0)) {
                                 triplets.emplace_back(i, n, -reference_load(i));
                             }
-
                             if (delta_q(i) != Precision(0)) {
                                 triplets.emplace_back(n, i, Precision(2) * delta_q(i));
                             }
@@ -290,8 +215,7 @@ bool ArcLengthControl::solve(
 
                         const DynamicMatrix solution = matrix_solve(augmented, rhs);
 
-                        logging::error(solution.rows() == n + 1 &&
-                                       solution.cols() == 1,
+                        logging::error(solution.rows() == n + 1 && solution.cols() == 1,
                             "ArcLengthControl: augmented solve returned an invalid shape");
                         logging::error(solution.allFinite(),
                             "ArcLengthControl: correction contains NaN/Inf entries");
@@ -300,12 +224,10 @@ bool ArcLengthControl::solve(
                         const Precision     dlambda = solution(n, 0);
 
                         lambda += dlambda;
-
                         return dq;
                     },
                     [&](const DynamicVector& residual) {
                         current_equilibrium_norm = residual_norm(residual, lambda);
-
                         return std::max(
                             current_equilibrium_norm,
                             arc_constraint_norm_(q, lambda)
@@ -315,11 +237,9 @@ bool ArcLengthControl::solve(
                     [&](Index     iteration,
                         Precision current_residual_norm,
                         Precision current_correction_norm,
-                        Precision convergence_order,
                         Index     line_search_iterations,
                         Time      assembly_ms,
-                        Time      solve_ms,
-                        bool      iteration_converged) {
+                        Time      solve_ms) {
                         (void) current_residual_norm;
 
                         if (on_iteration) {
@@ -329,11 +249,9 @@ bool ArcLengthControl::solve(
                                 lambda,
                                 current_equilibrium_norm,
                                 current_correction_norm,
-                                convergence_order,
                                 line_search_iterations,
                                 assembly_ms,
-                                solve_ms,
-                                iteration_converged
+                                solve_ms
                             );
                         }
                     }
@@ -344,8 +262,7 @@ bool ArcLengthControl::solve(
                     break;
                 }
 
-                if (!update_active_set ||
-                    update_active_set(q, lambda)) {
+                if (!update_active_set || update_active_set(q, lambda)) {
                     break;
                 }
 
@@ -394,13 +311,9 @@ bool ArcLengthControl::solve(
             ++cutback_count;
 
             logging::info(true,
-                "Increment rejected at lambda = ",
-                rejected_lambda,
-                "; reason = ",
-                attempt_failure_reason,
-                "; reducing increment to ",
-                increment_
-            );
+                "Increment rejected at lambda = ", rejected_lambda,
+                "; reason = ", attempt_failure_reason,
+                "; reducing increment to ", increment_);
 
             if (increment_ < minimum_increment) {
                 failure_reason_ = attempt_error_message.empty()
@@ -419,13 +332,10 @@ bool ArcLengthControl::solve(
             continue;
         }
 
-        if (adjusting_final_step_ &&
-            std::abs(lambda - Precision(1)) > tolerance) {
+        if (adjusting_final_step_ && std::abs(lambda - Precision(1)) > tolerance) {
             const Precision reached_lambda         = lambda;
-            const Precision achieved_delta_lambda =
-                lambda - lambda_accepted_;
-            const Precision remaining_delta_lambda =
-                Precision(1) - lambda_accepted_;
+            const Precision achieved_delta_lambda = lambda - lambda_accepted_;
+            const Precision remaining_delta_lambda = Precision(1) - lambda_accepted_;
 
             if (achieved_delta_lambda <= Precision(0)) {
                 q               = q_accepted_;
@@ -435,7 +345,6 @@ bool ArcLengthControl::solve(
                 if (rollback_increment_trial) {
                     rollback_increment_trial();
                 }
-
                 return false;
             }
 
@@ -453,19 +362,14 @@ bool ArcLengthControl::solve(
             ++cutback_count;
 
             logging::info(true,
-                "Arc-length step reached lambda = ",
-                reached_lambda,
-                " instead of 1; adjusting increment from ",
-                previous_increment,
-                " to ",
-                increment_
-            );
+                "Arc-length step reached lambda = ", reached_lambda,
+                " instead of 1; adjusting increment from ", previous_increment,
+                " to ", increment_);
 
             if (increment_ < minimum_increment) {
                 failure_reason_ = "MINIMUM_INCREMENT";
                 return false;
             }
-
             if (cutback_count > maximum_cutbacks) {
                 failure_reason_ = "MAXIMUM_FINAL_ADJUSTMENTS";
                 return false;
@@ -492,11 +396,10 @@ bool ArcLengthControl::solve(
         adapt_increment_();
 
         logging::info(true,
-            "Accepted increment "   , accepted_increments_,
-            ": lambda = "           , lambda,
+            "Accepted increment ", accepted_increments_,
+            ": lambda = ", lambda,
             ", Newton iterations = ", newton_.iterations(),
-            ", next increment = "  , increment_
-        );
+            ", next increment = ", increment_);
     }
 
     if (lambda < Precision(1) - tolerance) {
@@ -505,14 +408,6 @@ bool ArcLengthControl::solve(
     }
 
     return true;
-}
-
-Index ArcLengthControl::accepted_increments() const {
-    return accepted_increments_;
-}
-
-Precision ArcLengthControl::increment() const {
-    return increment_;
 }
 
 const char* ArcLengthControl::failure_reason() const {
@@ -534,18 +429,12 @@ void ArcLengthControl::reset_state_() {
 }
 
 void ArcLengthControl::configure_newton_() {
-    newton_.maximum_iterations       = maximum_iterations;
-    newton_.residual_tolerance       = tolerance;
-    newton_.stagnation_tolerance     = Precision(1e-3) * tolerance;
-    newton_.check_finite             = true;
-    newton_.early_failure_detection  = true;
-
-    // Arc-length Newton corrections contain both dq and dlambda, but the
-    // generic Newton line search can scale only the explicit state vector q.
-    // Scaling q while lambda already contains the full correction evaluates a
-    // point away from the augmented arc-length linearization, so globalization
-    // is left to the adaptive arc-length increment control.
-    newton_.line_search_enabled = false;
+    newton_.maximum_iterations      = maximum_iterations;
+    newton_.residual_tolerance      = tolerance;
+    newton_.stagnation_tolerance    = Precision(1e-3) * tolerance;
+    newton_.check_finite            = true;
+    newton_.early_failure_detection = true;
+    newton_.line_search_enabled     = false;
 }
 
 void ArcLengthControl::adapt_increment_() {
@@ -560,11 +449,7 @@ void ArcLengthControl::adapt_increment_() {
         increment_ *= cutback_factor;
     }
 
-    increment_ = std::clamp(
-        increment_,
-        minimum_increment,
-        maximum_increment
-    );
+    increment_ = std::clamp(increment_, minimum_increment, maximum_increment);
 }
 
 Precision ArcLengthControl::arc_constraint_norm_(

--- a/src/loadcase/tools/arc_length_control.cpp
+++ b/src/loadcase/tools/arc_length_control.cpp
@@ -99,7 +99,7 @@ bool ArcLengthControl::solve(
     logging::error(tolerance > Precision(0),
         "ArcLengthControl requires tolerance > 0");
     logging::error(initial_increment > Precision(0),
-        "ArcLengthControl requires INITIAL_INCREMENT > 0");
+        "ArcLengthControl requires initial_increment > 0");
     logging::error(minimum_increment > Precision(0),
         "ArcLengthControl requires minimum_increment > 0");
     logging::error(maximum_increment >= minimum_increment,

--- a/src/loadcase/tools/arc_length_control.cpp
+++ b/src/loadcase/tools/arc_length_control.cpp
@@ -1,6 +1,20 @@
 /**
  * @file arc_length_control.cpp
  * @brief Implements nonlinear arc-length control.
+ *
+ * The implementation follows nonlinear static equilibrium paths by solving the
+ * finite-element residual together with a scalar arc-length constraint. The path
+ * radius is adapted between accepted increments, while each attempted increment
+ * may be rolled back and retried when Newton convergence or final-load
+ * adjustment fails.
+ *
+ * All finite-element-specific work is delegated to callbacks supplied by the
+ * owning load case. This file only handles the reduced path-following algorithm,
+ * augmented Newton system, cutback/growth decisions, active-set restarts and
+ * state transaction wiring for nonlinear subsystems.
+ *
+ * @see ArcLengthControl
+ * @see NewtonSolver
  */
 
 #include "arc_length_control.h"
@@ -22,6 +36,45 @@ constexpr Index maximum_active_set_updates = 8;
 
 } // namespace
 
+/**
+ * Solves the nonlinear equilibrium path with an arc-length constraint.
+ *
+ * Each attempted increment starts from the last accepted reduced state `q` and
+ * load factor `lambda`. The first tangent predictor determines a load-direction
+ * correction and the current radius. Subsequent Newton iterations solve an
+ * augmented system containing both the reduced equilibrium residual and the
+ * spherical path constraint
+ *
+ *     ||Delta q||^2 + psi^2 load_scale^2 Delta lambda^2 = radius^2.
+ *
+ * Increment trial callbacks wrap the complete attempted path increment. They are
+ * committed only after the increment is accepted and rolled back for cutbacks,
+ * failed Newton solves, failed final-load adjustments or callback exceptions.
+ *
+ * The current arc-length implementation disables Newton line search because the
+ * generic line search scales only the explicit state vector while arc-length
+ * corrections also contain an implicit load-factor correction.
+ *
+ * After a converged augmented Newton solve, `update_active_set` may update
+ * discontinuous nonlinear state at the converged configuration. A reported
+ * change restarts Newton on the same path increment using the new state.
+ *
+ * @param q Reduced nonlinear unknown vector. On success it contains the final
+ *          accepted state. On failure it is restored to the last accepted state.
+ * @param lambda Load factor associated with `q`.
+ * @param reference_load Reduced reference load vector used by the arc-length
+ *                       predictor and augmented Newton system.
+ * @param evaluate Residual and tangent assembly at a supplied `q` and load
+ *                 factor.
+ * @param linear_solve Linearized solve with one right-hand side.
+ * @param matrix_solve Linearized solve for the augmented system.
+ * @param residual_norm Problem-specific equilibrium-residual measure.
+ * @param correction_norm Problem-specific correction-size measure.
+ * @param on_iteration Optional per-Newton-iteration reporting callback.
+ * @param on_increment Optional accepted-increment callback for result writing.
+ *
+ * @return `true` when the path reaches load factor one, otherwise `false`.
+ */
 bool ArcLengthControl::solve(
     DynamicVector&           q,
     Precision&               lambda,
@@ -74,6 +127,7 @@ bool ArcLengthControl::solve(
         "ArcLengthControl requires a correction norm callback");
 
     reset_state_();
+
     previous_delta_q_ = DynamicVector::Zero(q.size());
 
     Index cutback_count = 0;
@@ -95,6 +149,8 @@ bool ArcLengthControl::solve(
         std::string attempt_error_message;
         Index       active_set_updates     = 0;
 
+        // Treat analysis failures inside this attempted increment like Newton
+        // non-convergence so adaptive arc-length control can reduce the radius.
         try {
             if (begin_increment_trial) {
                 begin_increment_trial();
@@ -103,9 +159,17 @@ bool ArcLengthControl::solve(
             DynamicVector predictor_residual;
             SparseMatrix  predictor_tangent;
 
-            evaluate(q_accepted_, lambda_accepted_, predictor_residual, predictor_tangent);
+            evaluate(
+                q_accepted_,
+                lambda_accepted_,
+                predictor_residual,
+                predictor_tangent
+            );
 
-            DynamicVector dq_load = linear_solve(predictor_tangent, reference_load);
+            DynamicVector dq_load = linear_solve(
+                predictor_tangent,
+                reference_load
+            );
 
             logging::error(dq_load.allFinite(),
                 "ArcLengthControl: predictor contains NaN/Inf entries");
@@ -119,11 +183,14 @@ bool ArcLengthControl::solve(
 
             if (radius_scale_ <= Precision(0)) {
                 load_scale2_  = current_load_scale2;
-                radius_scale_ = std::sqrt(current_load_scale2 + psi2 * load_scale2_);
+                radius_scale_ = std::sqrt(
+                    current_load_scale2 + psi2 * load_scale2_
+                );
             }
 
-            const Precision predictor_norm =
-                std::sqrt(current_load_scale2 + psi2 * load_scale2_);
+            const Precision predictor_norm = std::sqrt(
+                current_load_scale2 + psi2 * load_scale2_
+            );
 
             Precision path_sign = Precision(1);
 
@@ -137,7 +204,9 @@ bool ArcLengthControl::solve(
 
             arc_radius_ = increment_ * radius_scale_;
 
-            Precision predictor_delta_lambda = path_sign * arc_radius_ / predictor_norm;
+            Precision predictor_delta_lambda =
+                path_sign * arc_radius_ / predictor_norm;
+
             const Precision remaining_delta_lambda = Precision(1) - lambda_accepted_;
 
             if (path_sign > Precision(0) &&
@@ -196,6 +265,7 @@ bool ArcLengthControl::solve(
                             if (reference_load(i) != Precision(0)) {
                                 triplets.emplace_back(i, n, -reference_load(i));
                             }
+
                             if (delta_q(i) != Precision(0)) {
                                 triplets.emplace_back(n, i, Precision(2) * delta_q(i));
                             }
@@ -215,7 +285,8 @@ bool ArcLengthControl::solve(
 
                         const DynamicMatrix solution = matrix_solve(augmented, rhs);
 
-                        logging::error(solution.rows() == n + 1 && solution.cols() == 1,
+                        logging::error(solution.rows() == n + 1 &&
+                                       solution.cols() == 1,
                             "ArcLengthControl: augmented solve returned an invalid shape");
                         logging::error(solution.allFinite(),
                             "ArcLengthControl: correction contains NaN/Inf entries");
@@ -224,10 +295,12 @@ bool ArcLengthControl::solve(
                         const Precision     dlambda = solution(n, 0);
 
                         lambda += dlambda;
+
                         return dq;
                     },
                     [&](const DynamicVector& residual) {
                         current_equilibrium_norm = residual_norm(residual, lambda);
+
                         return std::max(
                             current_equilibrium_norm,
                             arc_constraint_norm_(q, lambda)
@@ -262,7 +335,8 @@ bool ArcLengthControl::solve(
                     break;
                 }
 
-                if (!update_active_set || update_active_set(q, lambda)) {
+                if (!update_active_set ||
+                    update_active_set(q, lambda)) {
                     break;
                 }
 
@@ -311,9 +385,13 @@ bool ArcLengthControl::solve(
             ++cutback_count;
 
             logging::info(true,
-                "Increment rejected at lambda = ", rejected_lambda,
-                "; reason = ", attempt_failure_reason,
-                "; reducing increment to ", increment_);
+                "Increment rejected at lambda = ",
+                rejected_lambda,
+                "; reason = ",
+                attempt_failure_reason,
+                "; reducing increment to ",
+                increment_
+            );
 
             if (increment_ < minimum_increment) {
                 failure_reason_ = attempt_error_message.empty()
@@ -332,10 +410,13 @@ bool ArcLengthControl::solve(
             continue;
         }
 
-        if (adjusting_final_step_ && std::abs(lambda - Precision(1)) > tolerance) {
+        if (adjusting_final_step_ &&
+            std::abs(lambda - Precision(1)) > tolerance) {
             const Precision reached_lambda         = lambda;
-            const Precision achieved_delta_lambda = lambda - lambda_accepted_;
-            const Precision remaining_delta_lambda = Precision(1) - lambda_accepted_;
+            const Precision achieved_delta_lambda =
+                lambda - lambda_accepted_;
+            const Precision remaining_delta_lambda =
+                Precision(1) - lambda_accepted_;
 
             if (achieved_delta_lambda <= Precision(0)) {
                 q               = q_accepted_;
@@ -345,6 +426,7 @@ bool ArcLengthControl::solve(
                 if (rollback_increment_trial) {
                     rollback_increment_trial();
                 }
+
                 return false;
             }
 
@@ -362,14 +444,19 @@ bool ArcLengthControl::solve(
             ++cutback_count;
 
             logging::info(true,
-                "Arc-length step reached lambda = ", reached_lambda,
-                " instead of 1; adjusting increment from ", previous_increment,
-                " to ", increment_);
+                "Arc-length step reached lambda = ",
+                reached_lambda,
+                " instead of 1; adjusting increment from ",
+                previous_increment,
+                " to ",
+                increment_
+            );
 
             if (increment_ < minimum_increment) {
                 failure_reason_ = "MINIMUM_INCREMENT";
                 return false;
             }
+
             if (cutback_count > maximum_cutbacks) {
                 failure_reason_ = "MAXIMUM_FINAL_ADJUSTMENTS";
                 return false;
@@ -396,10 +483,11 @@ bool ArcLengthControl::solve(
         adapt_increment_();
 
         logging::info(true,
-            "Accepted increment ", accepted_increments_,
-            ": lambda = ", lambda,
+            "Accepted increment "   , accepted_increments_,
+            ": lambda = "           , lambda,
             ", Newton iterations = ", newton_.iterations(),
-            ", next increment = ", increment_);
+            ", next increment = "  , increment_
+        );
     }
 
     if (lambda < Precision(1) - tolerance) {
@@ -434,7 +522,13 @@ void ArcLengthControl::configure_newton_() {
     newton_.stagnation_tolerance    = Precision(1e-3) * tolerance;
     newton_.check_finite            = true;
     newton_.early_failure_detection = true;
-    newton_.line_search_enabled     = false;
+
+    // Arc-length Newton corrections contain both dq and dlambda, but the
+    // generic Newton line search can scale only the explicit state vector q.
+    // Scaling q while lambda already contains the full correction evaluates a
+    // point away from the augmented arc-length linearization, so globalization
+    // is left to the adaptive arc-length increment control.
+    newton_.line_search_enabled = false;
 }
 
 void ArcLengthControl::adapt_increment_() {
@@ -449,7 +543,11 @@ void ArcLengthControl::adapt_increment_() {
         increment_ *= cutback_factor;
     }
 
-    increment_ = std::clamp(increment_, minimum_increment, maximum_increment);
+    increment_ = std::clamp(
+        increment_,
+        minimum_increment,
+        maximum_increment
+    );
 }
 
 Precision ArcLengthControl::arc_constraint_norm_(

--- a/src/loadcase/tools/arc_length_control.cpp
+++ b/src/loadcase/tools/arc_length_control.cpp
@@ -13,10 +13,6 @@
  * augmented Newton system, cutback/growth decisions, active-set restarts and
  * state transaction wiring for nonlinear subsystems.
  *
- * Trial transactions are generic. Contact currently uses them for master
- * partner ownership and future nonlinear material models can use them for trial
- * stress states and committed internal variables.
- *
  * @see ArcLengthControl
  * @see NewtonSolver
  */
@@ -55,11 +51,9 @@ constexpr Index maximum_active_set_updates = 8;
  * committed only after the increment is accepted and rolled back for cutbacks,
  * failed Newton solves, failed final-load adjustments or callback exceptions.
  *
- * Line-search trial callbacks are forwarded to the Newton solver for consistency
- * with the load-control interface. The current arc-length implementation
- * disables line search because the generic Newton line search scales only the
- * explicit state vector, while arc-length corrections also contain an implicit
- * load-factor correction.
+ * The current arc-length implementation disables Newton line search because the
+ * generic line search scales only the explicit state vector while arc-length
+ * corrections also contain an implicit load-factor correction.
  *
  * After a converged augmented Newton solve, `update_active_set` may update
  * discontinuous nonlinear state at the converged configuration. A reported
@@ -78,7 +72,8 @@ constexpr Index maximum_active_set_updates = 8;
  * @param correction_norm Problem-specific correction-size measure.
  * @param on_iteration Optional per-Newton-iteration reporting callback.
  * @param on_increment Optional accepted-increment callback for result writing.
- * @param evaluate_residual Optional residual-only evaluation callback.
+ * @param evaluate_residual Reserved residual-only callback; currently unused
+ *                          because arc-length line search is disabled.
  *
  * @return `true` when the path reaches load factor one, otherwise `false`.
  */
@@ -95,6 +90,8 @@ bool ArcLengthControl::solve(
     const IncrementCallback& on_increment,
     const EvaluateResidual&  evaluate_residual
 ) {
+    (void) evaluate_residual;
+
     logging::error(maximum_increments > 0,
         "ArcLengthControl requires maximum_increments > 0");
     logging::error(maximum_iterations > 0,
@@ -102,7 +99,7 @@ bool ArcLengthControl::solve(
     logging::error(tolerance > Precision(0),
         "ArcLengthControl requires tolerance > 0");
     logging::error(initial_increment > Precision(0),
-        "ArcLengthControl requires initial_increment > 0");
+        "ArcLengthControl requires INITIAL_INCREMENT > 0");
     logging::error(minimum_increment > Precision(0),
         "ArcLengthControl requires minimum_increment > 0");
     logging::error(maximum_increment >= minimum_increment,
@@ -232,19 +229,6 @@ bool ArcLengthControl::solve(
             while (true) {
                 configure_newton_();
 
-                NewtonSolver::EvaluateResidual newton_evaluate_residual;
-                if (evaluate_residual) {
-                    newton_evaluate_residual =
-                        [&](const DynamicVector& current_q,
-                            DynamicVector&       residual) {
-                            evaluate_residual(
-                                current_q,
-                                lambda,
-                                residual
-                            );
-                        };
-                }
-
                 converged = newton_.solve(
                     q,
                     [&](const DynamicVector& current_q,
@@ -352,8 +336,7 @@ bool ArcLengthControl::solve(
                                 iteration_converged
                             );
                         }
-                    },
-                    newton_evaluate_residual
+                    }
                 );
 
                 if (!converged) {
@@ -562,11 +545,7 @@ void ArcLengthControl::configure_newton_() {
     // Scaling q while lambda already contains the full correction evaluates a
     // point away from the augmented arc-length linearization, so globalization
     // is left to the adaptive arc-length increment control.
-    newton_.line_search_enabled      = false;
-
-    newton_.begin_line_search_trial    = begin_line_search_trial;
-    newton_.commit_line_search_trial   = commit_line_search_trial;
-    newton_.rollback_line_search_trial = rollback_line_search_trial;
+    newton_.line_search_enabled = false;
 }
 
 void ArcLengthControl::adapt_increment_() {

--- a/src/loadcase/tools/arc_length_control.h
+++ b/src/loadcase/tools/arc_length_control.h
@@ -12,10 +12,8 @@
  * assembly, tangent assembly, constraint projection, sparse solves, convergence
  * measures and result writing remain responsibilities of the owning load case.
  *
- * Trial callbacks are generic nonlinear-state transactions. Contact currently
- * uses them to protect partner ownership during cutbacks and temporary residual
- * evaluations; future history-dependent materials can use the same mechanism
- * for trial stresses, internal variables and committed material state.
+ * Increment trial callbacks protect stateful nonlinear subsystems across failed
+ * path increments and cutbacks.
  *
  * @see ArcLengthControl
  * @see NewtonSolver
@@ -51,13 +49,9 @@ namespace tools {
  * operations are provided through callbacks, so the same class can operate on
  * constrained, reduced or otherwise transformed nonlinear systems.
  *
- * Stateful nonlinear subsystems are handled through two nested transaction
- * levels:
- *
- * - increment trials cover a complete attempted arc-length increment and are
- *   committed only after the increment is accepted,
- * - line-search trials are forwarded to the Newton solver for strategies that
- *   enable line search in the future.
+ * Stateful nonlinear subsystems are protected by increment trials that cover a
+ * complete attempted arc-length increment and are committed only after the
+ * increment is accepted.
  *
  * The optional active-set callback updates discontinuous nonlinear state after a
  * converged augmented Newton solve. If the active set changes, the controller
@@ -72,14 +66,6 @@ public:
         Precision            lambda,
         DynamicVector&       residual,
         SparseMatrix&        tangent
-    )>;
-
-    // Residual-only evaluation used when the Newton strategy evaluates
-    // temporary trial states without needing a tangent matrix.
-    using EvaluateResidual = std::function<void(
-        const DynamicVector& q,
-        Precision            lambda,
-        DynamicVector&       residual
     )>;
 
     // Linearized solve with a single right-hand side
@@ -114,11 +100,9 @@ public:
         Precision lambda,
         Precision residual_norm,
         Precision correction_norm,
-        Precision convergence_order,
         Index     line_search_iterations,
         Time      assembly_ms,
-        Time      solve_ms,
-        bool      converged
+        Time      solve_ms
     )>;
 
     // Accepted-increment reporting hook used for result writing and path storage
@@ -152,13 +136,10 @@ public:
         const ResidualNorm&      residual_norm,
         const CorrectionNorm&    correction_norm,
         const IterationCallback& on_iteration = {},
-        const IncrementCallback& on_increment = {},
-        const EvaluateResidual&  evaluate_residual = {}
+        const IncrementCallback& on_increment = {}
     );
 
-    Index       accepted_increments() const;
-    Precision   increment()           const;
-    const char* failure_reason()      const;
+    const char* failure_reason() const;
 
 public:
     // Nonlinear increment and Newton limits
@@ -186,11 +167,6 @@ public:
     TrialCallback begin_increment_trial;
     TrialCallback commit_increment_trial;
     TrialCallback rollback_increment_trial;
-
-    // Temporary line-search transaction nested inside the current increment
-    TrialCallback begin_line_search_trial;
-    TrialCallback commit_line_search_trial;
-    TrialCallback rollback_line_search_trial;
 
     // Optional discontinuous-state update after Newton convergence
     ActiveSetCallback update_active_set;

--- a/src/loadcase/tools/load_control.cpp
+++ b/src/loadcase/tools/load_control.cpp
@@ -55,8 +55,7 @@ constexpr Index maximum_active_set_updates = 8;
  *
  * After a converged Newton solve, `update_active_set` may update discontinuous
  * nonlinear state at the converged configuration. If it reports a change, Newton
- * is restarted at the same target load factor. This is used for contact partner
- * ownership today and is intentionally independent of any specific subsystem.
+ * is restarted at the same target load factor.
  *
  * @param q Reduced nonlinear unknown vector. On success it contains the final
  *          accepted state. On failure it is restored to the last accepted state.
@@ -187,11 +186,9 @@ bool LoadControl::solve(
                     [&](Index     iteration,
                         Precision current_residual_norm,
                         Precision current_correction_norm,
-                        Precision convergence_order,
                         Index     line_search_iterations,
                         Time      assembly_ms,
-                        Time      solve_ms,
-                        bool      iteration_converged) {
+                        Time      solve_ms) {
                         if (on_iteration) {
                             on_iteration(
                                 accepted_increments_ + 1,
@@ -199,11 +196,9 @@ bool LoadControl::solve(
                                 target_lambda,
                                 current_residual_norm,
                                 current_correction_norm,
-                                convergence_order,
                                 line_search_iterations,
                                 assembly_ms,
-                                solve_ms,
-                                iteration_converged
+                                solve_ms
                             );
                         }
                     },
@@ -333,14 +328,6 @@ bool LoadControl::solve(
     }
 
     return true;
-}
-
-Index LoadControl::accepted_increments() const {
-    return accepted_increments_;
-}
-
-Precision LoadControl::increment() const {
-    return increment_;
 }
 
 const char* LoadControl::failure_reason() const {

--- a/src/loadcase/tools/load_control.h
+++ b/src/loadcase/tools/load_control.h
@@ -114,11 +114,9 @@ public:
         Precision lambda,
         Precision residual_norm,
         Precision correction_norm,
-        Precision convergence_order,
         Index     line_search_iterations,
         Time      assembly_ms,
-        Time      solve_ms,
-        bool      converged
+        Time      solve_ms
     )>;
 
     // Accepted-increment reporting hook used for result writing and path storage
@@ -155,9 +153,7 @@ public:
         const EvaluateResidual&  evaluate_residual = {}
     );
 
-    Index       accepted_increments() const;
-    Precision   increment()           const;
-    const char* failure_reason()      const;
+    const char* failure_reason() const;
 
 public:
     // Nonlinear increment and Newton limits

--- a/src/loadcase/tools/newton_solver.cpp
+++ b/src/loadcase/tools/newton_solver.cpp
@@ -41,7 +41,7 @@ namespace tools {
  *
  * 1. Evaluate the residual vector and tangent matrix at the current state.
  * 2. Compute the caller-defined residual norm.
- * 3. Update convergence diagnostics and failure-detection counters.
+ * 3. Update failure-detection counters.
  * 4. Accept the current state when the residual tolerance is satisfied.
  * 5. Solve the linearized system for the Newton correction.
  * 6. Optionally perform a backtracking line search.
@@ -166,8 +166,7 @@ bool NewtonSolver::solve(
 
         iterations_ = iteration;
 
-        // Shift the previously evaluated residual norms before storing the
-        // current value
+        // Shift the previously evaluated residual before storing the current one
         update_residual_history_();
 
         // Evaluate the problem-specific residual convergence measure
@@ -182,8 +181,6 @@ bool NewtonSolver::solve(
             initial_residual_norm_ = last_residual_norm_;
         }
 
-        // Update convergence diagnostics from the current residual history
-        update_convergence_order_();
         update_failure_counters_();
 
         // Residual convergence is checked before solving another linearized
@@ -199,11 +196,9 @@ bool NewtonSolver::solve(
                     iteration,
                     last_residual_norm_,
                     last_correction_norm_,
-                    convergence_order_,
                     Index(0),
                     assembly_timer.elapsed(),
-                    Time(0),
-                    true
+                    Time(0)
                 );
             }
 
@@ -218,11 +213,9 @@ bool NewtonSolver::solve(
                     iteration,
                     last_residual_norm_,
                     last_correction_norm_,
-                    convergence_order_,
                     Index(0),
                     assembly_timer.elapsed(),
-                    Time(0),
-                    false
+                    Time(0)
                 );
             }
 
@@ -432,11 +425,9 @@ bool NewtonSolver::solve(
                 iteration,
                 last_residual_norm_,
                 last_correction_norm_,
-                convergence_order_,
                 line_search_iterations,
                 assembly_timer.elapsed(),
-                solve_timer.elapsed(),
-                false
+                solve_timer.elapsed()
             );
         }
 
@@ -475,46 +466,6 @@ Index NewtonSolver::iterations() const {
 }
 
 /**
- * Returns the residual norm evaluated at the initial nonlinear state.
- *
- * @return Initial residual norm of the most recent solve.
- */
-Precision NewtonSolver::initial_residual_norm() const {
-    return initial_residual_norm_;
-}
-
-/**
- * Returns the most recently evaluated residual norm.
- *
- * @return Last residual norm of the most recent solve.
- */
-Precision NewtonSolver::last_residual_norm() const {
-    return last_residual_norm_;
-}
-
-/**
- * Returns the norm of the most recently accepted Newton correction.
- *
- * The value is zero when convergence was detected before solving another
- * linearized system.
- *
- * @return Last accepted correction norm.
- */
-Precision NewtonSolver::last_correction_norm() const {
-    return last_correction_norm_;
-}
-
-/**
- * Returns the observed local convergence order estimated from the three most
- * recent positive residual norms.
- *
- * @return Estimated convergence order or zero when it cannot be determined.
- */
-Precision NewtonSolver::convergence_order() const {
-    return convergence_order_;
-}
-
-/**
  * Returns the step length of the most recently accepted Newton correction.
  *
  * A value below one indicates that the line search reduced the full Newton
@@ -524,63 +475,6 @@ Precision NewtonSolver::convergence_order() const {
  */
 Precision NewtonSolver::last_step_length() const {
     return last_step_length_;
-}
-
-/**
- * Reports whether the most recent solve exceeded the configured residual
- * divergence factor.
- *
- * @return `true` when the solve failed by divergence.
- */
-bool NewtonSolver::failed_by_divergence() const {
-    return failed_by_divergence_;
-}
-
-/**
- * Reports whether the residual increased during too many consecutive
- * iterations.
- *
- * @return `true` when the solve failed by repeated residual increase.
- */
-bool NewtonSolver::failed_by_residual_increase() const {
-    return failed_by_residual_increase_;
-}
-
-/**
- * Reports whether the residual or correction stagnated.
- *
- * @return `true` when the solve failed by stagnation.
- */
-bool NewtonSolver::failed_by_stagnation() const {
-    return failed_by_stagnation_;
-}
-
-/**
- * Reports whether the current residual remained above the configured fraction
- * of the initial residual.
- *
- * @return `true` when the solve failed by insufficient residual reduction.
- */
-bool NewtonSolver::failed_by_poor_reduction() const {
-    return failed_by_poor_reduction_;
-}
-
-/**
- * Reports whether the line search failed to find a residual-reducing trial.
- *
- * @return `true` when the solve failed during line search.
- */
-bool NewtonSolver::failed_by_line_search() const {
-    return failed_by_line_search_;
-}
-
-/**
- * Reports whether the solver exhausted the configured Newton iteration limit.
- *
- * @return `true` when the solve failed by reaching the maximum iteration count.
- */
-bool NewtonSolver::failed_by_maximum_iterations() const {
-    return failed_by_maximum_iterations_;
 }
 
 /**
@@ -630,13 +524,11 @@ void NewtonSolver::reset_state_() {
     // Reset iteration and convergence diagnostics
     iterations_ = 0;
 
-    initial_residual_norm_           = Precision(0);
-    last_residual_norm_              = Precision(0);
-    last_correction_norm_            = Precision(0);
-    previous_residual_norm_          = Precision(0);
-    previous_previous_residual_norm_ = Precision(0);
-    convergence_order_               = Precision(0);
-    last_step_length_                = Precision(1);
+    initial_residual_norm_  = Precision(0);
+    last_residual_norm_     = Precision(0);
+    last_correction_norm_   = Precision(0);
+    previous_residual_norm_ = Precision(0);
+    last_step_length_       = Precision(1);
 
     // Reset consecutive failure-detection counters
     residual_increase_count_ = 0;
@@ -652,60 +544,11 @@ void NewtonSolver::reset_state_() {
 }
 
 /**
- * Shifts the stored residual norms before a newly evaluated norm is assigned.
- *
- * After the update:
- *
- * - `previous_previous_residual_norm_` contains the residual from two
- *   evaluations ago,
- * - `previous_residual_norm_` contains the immediately preceding residual,
- * - `last_residual_norm_` may be overwritten with the current residual.
+ * Stores the previously evaluated residual norm before the current norm is
+ * assigned.
  */
 void NewtonSolver::update_residual_history_() {
-    previous_previous_residual_norm_ = previous_residual_norm_;
-    previous_residual_norm_          = last_residual_norm_;
-}
-
-/**
- * Estimates the observed local order of convergence from three consecutive
- * residual norms.
- *
- * For residual sequence `r0`, `r1`, `r2`, the order is estimated as
- *
- *     p = log(r2 / r1) / log(r1 / r0).
- *
- * The estimate is suppressed when fewer than three residuals are available,
- * when one residual is non-positive or when the denominator is numerically
- * zero.
- */
-void NewtonSolver::update_convergence_order_() {
-    convergence_order_ = Precision(0);
-
-    // Three residual evaluations are required for the logarithmic estimate
-    if (iterations_ < 3) {
-        return;
-    }
-
-    const Precision residual_0 = previous_previous_residual_norm_;
-    const Precision residual_1 = previous_residual_norm_;
-    const Precision residual_2 = last_residual_norm_;
-
-    // The logarithmic ratios require strictly positive residual norms
-    if (residual_0 <= Precision(0) ||
-        residual_1 <= Precision(0) ||
-        residual_2 <= Precision(0)) {
-        return;
-    }
-
-    const Precision numerator   = std::log(residual_2 / residual_1);
-    const Precision denominator = std::log(residual_1 / residual_0);
-
-    // Nearly identical preceding residuals make the estimated order singular
-    if (std::abs(denominator) <= Precision(1e-14)) {
-        return;
-    }
-
-    convergence_order_ = numerator / denominator;
+    previous_residual_norm_ = last_residual_norm_;
 }
 
 /**

--- a/src/loadcase/tools/newton_solver.h
+++ b/src/loadcase/tools/newton_solver.h
@@ -17,9 +17,10 @@
  * callbacks allow stateful nonlinear subsystems to begin, commit and roll back
  * temporary evaluations performed during the line search.
  *
- * The solver additionally records convergence diagnostics and can terminate
- * early when it detects divergence, repeated residual growth, residual
- * stagnation or insufficient reduction from the initial residual.
+ * The solver additionally records the diagnostics required for nonlinear path
+ * control and can terminate early when it detects divergence, repeated residual
+ * growth, residual stagnation or insufficient reduction from the initial
+ * residual.
  *
  * Increment management, load-factor adaptation, active-set restarts and result
  * writing remain responsibilities of the calling solution strategy.
@@ -88,9 +89,9 @@ namespace tools {
  * - `commit_line_search_trial` accepts the evaluated trial state,
  * - `rollback_line_search_trial` restores the state before the trial.
  *
-     * These callbacks are optional for purely state-independent problems but are
-     * required when residual evaluation modifies material history, active-set
-     * ownership or other persistent trial data.
+ * These callbacks are optional for purely state-independent problems but are
+ * required when residual evaluation modifies material history or other
+ * persistent trial data.
  *
  * A solver object may be reused for multiple nonlinear solves. Diagnostic and
  * failure state is reset at the beginning of every call to `solve`.
@@ -141,11 +142,9 @@ public:
         Index     iteration,
         Precision residual_norm,
         Precision correction_norm,
-        Precision convergence_order,
         Index     line_search_iterations,
         Time      assembly_ms,
-        Time      solve_ms,
-        bool      converged
+        Time      solve_ms
     )>;
 
     // Transaction callback used to manage temporary state during line-search
@@ -202,21 +201,9 @@ public:
         const EvaluateResidual&  evaluate_residual = {}
     );
 
-    // Diagnostics of the most recent nonlinear solve
-    Index     iterations()            const;
-    Precision initial_residual_norm() const;
-    Precision last_residual_norm()    const;
-    Precision last_correction_norm()  const;
-    Precision convergence_order()     const;
-    Precision last_step_length()      const;
-
-    // Failure classification of the most recent nonlinear solve
-    bool failed_by_divergence()         const;
-    bool failed_by_residual_increase()  const;
-    bool failed_by_stagnation()         const;
-    bool failed_by_poor_reduction()     const;
-    bool failed_by_line_search()        const;
-    bool failed_by_maximum_iterations() const;
+    // Diagnostics required by nonlinear path controllers
+    Index     iterations()       const;
+    Precision last_step_length() const;
 
     // Textual classification of the most recent failure
     const char* failure_reason() const;
@@ -225,13 +212,11 @@ private:
     // Iteration state of the most recent solve
     Index iterations_ = 0;
 
-    Precision initial_residual_norm_           = Precision(0);
-    Precision last_residual_norm_              = Precision(0);
-    Precision last_correction_norm_            = Precision(0);
-    Precision previous_residual_norm_          = Precision(0);
-    Precision previous_previous_residual_norm_ = Precision(0);
-    Precision convergence_order_               = Precision(0);
-    Precision last_step_length_                = Precision(1);
+    Precision initial_residual_norm_  = Precision(0);
+    Precision last_residual_norm_     = Precision(0);
+    Precision last_correction_norm_   = Precision(0);
+    Precision previous_residual_norm_ = Precision(0);
+    Precision last_step_length_       = Precision(1);
 
     // Consecutive failure-detection counters
     Index residual_increase_count_ = 0;
@@ -248,10 +233,9 @@ private:
     // Reset all diagnostics and failure state before a new solve
     void reset_state_();
 
-    // Update residual history, observed convergence order and consecutive
-    // failure-detection counters after each residual evaluation
+    // Update residual history and failure-detection counters after each residual
+    // evaluation
     void update_residual_history_();
-    void update_convergence_order_();
     void update_failure_counters_();
 
     // Evaluate the configured early-failure criteria

--- a/src/loadcase/tools/nonlinear_state_manager.cpp
+++ b/src/loadcase/tools/nonlinear_state_manager.cpp
@@ -34,9 +34,27 @@ namespace fem {
 namespace loadcase {
 namespace tools {
 
+/**
+ * Creates the nonlinear state coordinator for one load-case execution.
+ *
+ * The caller-visible material-state pointer is saved first and restored by the
+ * destructor. Contact penalty adaptation is reset once here, which returns each
+ * contact to its user-provided starting penalty while deliberately allowing later
+ * adaptations to persist across load increments and cutbacks within this
+ * analysis.
+ *
+ * If assigned materials require history variables, matching committed and trial
+ * `ELEMENT_MP` fields are allocated and initialized in the global material-point
+ * enumeration owned by `ModelData`. Models without constitutive history avoid
+ * allocating those fields entirely.
+ *
+ * @param model Model whose material and contact state is coordinated.
+ */
 NonlinearStateManager::NonlinearStateManager(model::Model& model)
     : model_(model),
       previous_material_state_(model._data->material_state) {
+    // Penalty continuation belongs to the complete nonlinear analysis, not to
+    // individual increments. Reset it exactly once when the manager is created.
     for (const auto& contact : model_._data->contacts) {
         contact.reset_penalty_adaptation();
     }
@@ -46,6 +64,8 @@ NonlinearStateManager::NonlinearStateManager(model::Model& model)
         return;
     }
 
+    // Allocate separate accepted and working constitutive history fields. Both
+    // use the same global element/material-point row ordering.
     committed_material_state_ = model_._data->create_field(
         "MATERIAL_STATE_COMMITTED",
         model::FieldDomain::ELEMENT_MP,
@@ -66,10 +86,21 @@ NonlinearStateManager::NonlinearStateManager(model::Model& model)
     reset_material_state();
 }
 
+/**
+ * Restores the material-state field that was visible before this manager was
+ * created. The manager-owned committed/trial buffers then leave scope normally.
+ */
 NonlinearStateManager::~NonlinearStateManager() {
     model_._data->material_state = previous_material_state_;
 }
 
+/**
+ * Restarts the active constitutive trial from the last committed material state.
+ *
+ * Independent Newton, predictor and line-search evaluations must not inherit
+ * in-place material updates from a previously rejected evaluation. Copying the
+ * committed values before rebinding the trial field provides that isolation.
+ */
 void NonlinearStateManager::reset_material_state() {
     if (!committed_material_state_) {
         return;
@@ -79,6 +110,13 @@ void NonlinearStateManager::reset_material_state() {
     bind_material_state();
 }
 
+/**
+ * Accepts the current material trial as the new constitutive history.
+ *
+ * The committed and trial field objects are swapped instead of copying the
+ * accepted data twice. The new trial buffer is then initialized from the accepted
+ * state so the next independent evaluation starts from identical history.
+ */
 void NonlinearStateManager::commit_material_state() {
     if (!committed_material_state_) {
         return;
@@ -89,24 +127,56 @@ void NonlinearStateManager::commit_material_state() {
     bind_material_state();
 }
 
+/**
+ * Opens one nested transactional contact trial.
+ *
+ * Surface mortar has no discrete partner state to freeze or refresh. Predictor,
+ * line-search, increment and post-Newton transactions therefore share the same
+ * begin operation and differ only in how the nonlinear controller commits or
+ * rolls them back.
+ */
 void NonlinearStateManager::begin_contact_trial() {
     for (const auto& contact : model_._data->contacts) {
         contact.begin_trial();
     }
 }
 
+/**
+ * Commits the innermost contact trial into its parent transaction or committed
+ * contact history. Geometry is not involved because it is never stored.
+ */
 void NonlinearStateManager::commit_contact_trial() {
     for (const auto& contact : model_._data->contacts) {
         contact.commit_trial();
     }
 }
 
+/**
+ * Discards the innermost contact trial and restores the parent multiplier and
+ * accepted evaluation state. Current geometry requires no explicit restoration.
+ */
 void NonlinearStateManager::rollback_contact_trial() {
     for (const auto& contact : model_._data->contacts) {
         contact.rollback_trial();
     }
 }
 
+/**
+ * Updates contact after a converged inner Newton solve.
+ *
+ * Penalty adaptation is evaluated first from the penetration reached after the
+ * previous multiplier augmentation. If penetration did not decrease by at least
+ * 20 %, the effective penalty is increased by one decade. The following
+ * multiplier update then uses this adapted penalty. The effective penalty was
+ * reset only when this manager was constructed and therefore persists across
+ * accepted increments.
+ *
+ * The path controller interprets `false` as a request to repeat Newton at the
+ * same load factor with the updated contact history.
+ *
+ * @return `true` when no contact multiplier changed; `false` when at least one
+ *         contact requires another Newton equilibrium solve.
+ */
 bool NonlinearStateManager::update_contact_active_set() {
     bool changed = false;
 
@@ -125,6 +195,10 @@ bool NonlinearStateManager::update_contact_active_set() {
     return !changed;
 }
 
+/**
+ * Publishes the manager-owned trial material field as the active constitutive
+ * history and restores the semantic names of committed and trial buffers.
+ */
 void NonlinearStateManager::bind_material_state() {
     committed_material_state_->name = "MATERIAL_STATE_COMMITTED";
     trial_material_state_->name     = "MATERIAL_STATE";

--- a/src/loadcase/tools/nonlinear_state_manager.cpp
+++ b/src/loadcase/tools/nonlinear_state_manager.cpp
@@ -34,27 +34,9 @@ namespace fem {
 namespace loadcase {
 namespace tools {
 
-/**
- * Creates the nonlinear state coordinator for one load-case execution.
- *
- * The caller-visible material-state pointer is saved first and restored by the
- * destructor. Contact penalty adaptation is reset once here, which returns each
- * contact to its user-provided starting penalty while deliberately allowing later
- * adaptations to persist across load increments and cutbacks within this
- * analysis.
- *
- * If assigned materials require history variables, matching committed and trial
- * `ELEMENT_MP` fields are allocated and initialized in the global material-point
- * enumeration owned by `ModelData`. Models without constitutive history avoid
- * allocating those fields entirely.
- *
- * @param model Model whose material and contact state is coordinated.
- */
 NonlinearStateManager::NonlinearStateManager(model::Model& model)
     : model_(model),
       previous_material_state_(model._data->material_state) {
-    // Penalty continuation belongs to the complete nonlinear analysis, not to
-    // individual increments. Reset it exactly once when the manager is created.
     for (const auto& contact : model_._data->contacts) {
         contact.reset_penalty_adaptation();
     }
@@ -64,8 +46,6 @@ NonlinearStateManager::NonlinearStateManager(model::Model& model)
         return;
     }
 
-    // Allocate separate accepted and working constitutive history fields. Both
-    // use the same global element/material-point row ordering.
     committed_material_state_ = model_._data->create_field(
         "MATERIAL_STATE_COMMITTED",
         model::FieldDomain::ELEMENT_MP,
@@ -86,21 +66,10 @@ NonlinearStateManager::NonlinearStateManager(model::Model& model)
     reset_material_state();
 }
 
-/**
- * Restores the material-state field that was visible before this manager was
- * created. The manager-owned committed/trial buffers then leave scope normally.
- */
 NonlinearStateManager::~NonlinearStateManager() {
     model_._data->material_state = previous_material_state_;
 }
 
-/**
- * Restarts the active constitutive trial from the last committed material state.
- *
- * Independent Newton, predictor and line-search evaluations must not inherit
- * in-place material updates from a previously rejected evaluation. Copying the
- * committed values before rebinding the trial field provides that isolation.
- */
 void NonlinearStateManager::reset_material_state() {
     if (!committed_material_state_) {
         return;
@@ -110,13 +79,6 @@ void NonlinearStateManager::reset_material_state() {
     bind_material_state();
 }
 
-/**
- * Accepts the current material trial as the new constitutive history.
- *
- * The committed and trial field objects are swapped instead of copying the
- * accepted data twice. The new trial buffer is then initialized from the accepted
- * state so the next independent evaluation starts from identical history.
- */
 void NonlinearStateManager::commit_material_state() {
     if (!committed_material_state_) {
         return;
@@ -127,69 +89,24 @@ void NonlinearStateManager::commit_material_state() {
     bind_material_state();
 }
 
-/**
- * Opens a transactional contact trial for an increment or post-Newton update.
- *
- * Surface mortar has no discrete partner state to refresh. The operation therefore
- * copies only multiplier/evaluation history while subsequent assemblies continue
- * to reconstruct geometry from the current nodal configuration.
- */
-void NonlinearStateManager::begin_contact_update_trial() {
+void NonlinearStateManager::begin_contact_trial() {
     for (const auto& contact : model_._data->contacts) {
         contact.begin_trial();
     }
 }
 
-/**
- * Opens a nested transactional contact trial for predictor or line-search work.
- *
- * The current surface-to-surface formulation gives this trial the same state
- * semantics as an update trial. The separate method name is retained because the
- * path controllers distinguish temporary candidate evaluations from outer
- * increment/augmentation transactions.
- */
-void NonlinearStateManager::begin_contact_frozen_trial() {
-    for (const auto& contact : model_._data->contacts) {
-        contact.begin_trial();
-    }
-}
-
-/**
- * Commits the innermost contact trial into its parent transaction or committed
- * contact history. Geometry is not involved because it is never stored.
- */
 void NonlinearStateManager::commit_contact_trial() {
     for (const auto& contact : model_._data->contacts) {
         contact.commit_trial();
     }
 }
 
-/**
- * Discards the innermost contact trial and restores the parent multiplier and
- * accepted evaluation state. Current geometry requires no explicit restoration.
- */
 void NonlinearStateManager::rollback_contact_trial() {
     for (const auto& contact : model_._data->contacts) {
         contact.rollback_trial();
     }
 }
 
-/**
- * Updates contact after a converged inner Newton solve.
- *
- * Penalty adaptation is evaluated first from the penetration reached after the
- * previous multiplier augmentation. If penetration did not decrease by at least
- * 20 %, the effective penalty is increased by one decade. The following
- * multiplier update then uses this adapted penalty. The effective penalty was
- * reset only when this manager was constructed and therefore persists across
- * accepted increments.
- *
- * The path controller interprets `false` as a request to repeat Newton at the
- * same load factor with the updated contact history.
- *
- * @return `true` when no contact multiplier changed; `false` when at least one
- *         contact requires another Newton equilibrium solve.
- */
 bool NonlinearStateManager::update_contact_active_set() {
     bool changed = false;
 
@@ -208,10 +125,6 @@ bool NonlinearStateManager::update_contact_active_set() {
     return !changed;
 }
 
-/**
- * Publishes the manager-owned trial material field as the active constitutive
- * history and restores the semantic names of committed and trial buffers.
- */
 void NonlinearStateManager::bind_material_state() {
     committed_material_state_->name = "MATERIAL_STATE_COMMITTED";
     trial_material_state_->name     = "MATERIAL_STATE";

--- a/src/loadcase/tools/nonlinear_state_manager.h
+++ b/src/loadcase/tools/nonlinear_state_manager.h
@@ -59,10 +59,8 @@ public:
     void reset_material_state();
     void commit_material_state();
 
-    // Contact transactions. Surface mortar always recomputes geometry, so update
-    // and frozen trials differ only by their role in the nonlinear controller.
-    void begin_contact_update_trial();
-    void begin_contact_frozen_trial();
+    // Nested contact multiplier/evaluation transactions
+    void begin_contact_trial();
     void commit_contact_trial();
     void rollback_contact_trial();
 


### PR DESCRIPTION
## Summary

Remove dead nonlinear solver API and state plumbing without introducing new abstractions or changing the numerical algorithms.

## Changes

- remove unreachable Arc-Length residual-only and line-search callback API; Arc-Length continues to keep Newton line search disabled
- remove the unused Newton convergence-order calculation and its propagation through iteration callbacks
- remove unused Newton diagnostic/failure getters while retaining the internal state required by failure detection
- remove unused `accepted_increments()` and `increment()` getters from both path controllers
- remove the unused `converged` field from iteration callbacks
- merge the identical contact trial entry points into `begin_contact_trial()` now that contact geometry is always reconstructed and no partner state is frozen
- remove redundant `final_internal` copies from nonlinear residual/tangent evaluations and create it only for final result assembly
- update stale contact-state comments while preserving the existing numerical documentation

## Behavior

No numerical behavior change is intended. Load-control line search remains intact. Arc-length line search remains disabled exactly as before. Contact augmented-Lagrange state handling and penalty adaptation are unchanged; only duplicate transaction entry points were consolidated.

## Validation

Reviewed the branch diff against `master` and checked the removed call sites after the API changes. Current diff: 9 files, +82 / -371. A local build is not available in this environment, so the compile/regression check is left to repository CI.