### PR TITLE
Add Apple Accelerate sparse solver backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(FEMASTER_BUILD_TESTS "Build and register the GoogleTest executable" OFF)
 option(FEMASTER_ENABLE_CUDA "Build CUDA solver backends" OFF)
 option(FEMASTER_ENABLE_CUDSS "Use NVIDIA cuDSS for CUDA sparse direct solves" OFF)
 option(FEMASTER_ENABLE_MKL "Use Intel oneMKL for Eigen operations and PARDISO" OFF)
+option(FEMASTER_ENABLE_ACCELERATE "Use Apple Accelerate for sparse direct solves" ${APPLE})
 option(FEMASTER_MKL_SEQUENTIAL "Use the sequential oneMKL threading layer" OFF)
 option(FEMASTER_MKL_STATIC "Link the oneMKL component libraries statically" ON)
 option(FEMASTER_ENABLE_OPENMP "Enable OpenMP for FEMaster CPU loops" OFF)
@@ -63,6 +64,14 @@ endif()
 
 if(FEMASTER_ENABLE_CUDA AND APPLE)
     message(FATAL_ERROR "CUDA is not supported by current NVIDIA toolkits on macOS")
+endif()
+
+if(FEMASTER_ENABLE_ACCELERATE AND NOT APPLE)
+    message(FATAL_ERROR "FEMASTER_ENABLE_ACCELERATE is supported only on Apple platforms")
+endif()
+
+if(FEMASTER_ENABLE_ACCELERATE AND FEMASTER_ENABLE_MKL)
+    message(FATAL_ERROR "FEMASTER_ENABLE_ACCELERATE and FEMASTER_ENABLE_MKL are mutually exclusive")
 endif()
 
 if(FEMASTER_FULLY_STATIC AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux"))
@@ -297,6 +306,15 @@ if(FEMASTER_ENABLE_MKL)
             )
         endif()
     endif()
+endif()
+
+# -----------------------------------------------------------------------------
+# Apple Accelerate
+# -----------------------------------------------------------------------------
+if(FEMASTER_ENABLE_ACCELERATE)
+    find_library(FEMASTER_ACCELERATE_FRAMEWORK Accelerate REQUIRED)
+    target_link_libraries(femaster_core PUBLIC "${FEMASTER_ACCELERATE_FRAMEWORK}")
+    target_compile_definitions(femaster_core PUBLIC USE_ACCELERATE)
 endif()
 
 # -----------------------------------------------------------------------------
@@ -537,6 +555,7 @@ message(STATUS "  Double precision     : ${FEMASTER_DOUBLE_PRECISION}")
 message(STATUS "  OpenMP loops         : ${FEMASTER_ENABLE_OPENMP} (${FEMASTER_OPENMP_RUNTIME})")
 message(STATUS "  oneMKL               : ${FEMASTER_ENABLE_MKL}")
 message(STATUS "    link/threading     : ${FEMASTER_MKL_LINK} / ${FEMASTER_MKL_THREADING}")
+message(STATUS "  Apple Accelerate     : ${FEMASTER_ENABLE_ACCELERATE}")
 message(STATUS "  CUDA                 : ${FEMASTER_ENABLE_CUDA} (${FEMASTER_CUDA_VERSION})")
 message(STATUS "  cuDSS                : ${FEMASTER_ENABLE_CUDSS} (${FEMASTER_CUDSS_VERSION})")
 message(STATUS "  Static C/C++ runtime : ${FEMASTER_STATIC_RUNTIME}")
@@ -551,6 +570,7 @@ add_custom_target(femaster-info
         COMMAND ${CMAKE_COMMAND} -E echo "Compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}"
         COMMAND ${CMAKE_COMMAND} -E echo "OpenMP: ${FEMASTER_ENABLE_OPENMP} (${FEMASTER_OPENMP_RUNTIME})"
         COMMAND ${CMAKE_COMMAND} -E echo "oneMKL: ${FEMASTER_ENABLE_MKL} (${FEMASTER_MKL_LINK}, ${FEMASTER_MKL_THREADING})"
+        COMMAND ${CMAKE_COMMAND} -E echo "Apple Accelerate: ${FEMASTER_ENABLE_ACCELERATE}"
         COMMAND ${CMAKE_COMMAND} -E echo "CUDA: ${FEMASTER_ENABLE_CUDA} (${FEMASTER_CUDA_VERSION})"
         COMMAND ${CMAKE_COMMAND} -E echo "cuDSS: ${FEMASTER_ENABLE_CUDSS} (${FEMASTER_CUDSS_VERSION})"
         VERBATIM

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -213,6 +213,9 @@
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "FEMASTER_ENABLE_ACCELERATE": "OFF"
       }
     },
     {
@@ -221,11 +224,28 @@
       "inherits": "macos-base"
     },
     {
-      "name": "macos-openmp",
+      "name": "macos-accelerate",
+      "displayName": "macOS CPU + Accelerate",
+      "inherits": "macos-base",
+      "cacheVariables": {
+        "FEMASTER_ENABLE_ACCELERATE": "ON"
+      }
+    },
+    {
+      "name": "macos-omp",
       "displayName": "macOS CPU + OpenMP",
       "inherits": "macos-base",
       "cacheVariables": {
         "FEMASTER_ENABLE_OPENMP": "ON"
+      }
+    },
+    {
+      "name": "macos-omp-accelerate",
+      "displayName": "macOS CPU + OpenMP + Accelerate",
+      "inherits": "macos-base",
+      "cacheVariables": {
+        "FEMASTER_ENABLE_OPENMP": "ON",
+        "FEMASTER_ENABLE_ACCELERATE": "ON"
       }
     }
   ],
@@ -322,8 +342,18 @@
       "jobs": 8
     },
     {
-      "name": "macos-openmp",
-      "configurePreset": "macos-openmp",
+      "name": "macos-accelerate",
+      "configurePreset": "macos-accelerate",
+      "jobs": 8
+    },
+    {
+      "name": "macos-omp",
+      "configurePreset": "macos-omp",
+      "jobs": 8
+    },
+    {
+      "name": "macos-omp-accelerate",
+      "configurePreset": "macos-omp-accelerate",
       "jobs": 8
     }
   ]

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -3,9 +3,11 @@ FEMaster Third-Party Software Notices
 
 FEMaster itself is licensed under the MIT License. See LICENSE.txt.
 
-This distribution contains or links against the third-party components listed
-below. Their original license texts and required notices are preserved in the
-licenses directory. Those original files govern the corresponding components.
+FEMaster contains, links against or optionally uses the third-party components
+listed below. License texts and notices for components distributed with FEMaster
+are preserved in the licenses directory. System frameworks supplied by the
+operating system are identified separately and are not redistributed by
+FEMaster.
 
 argparse
 --------
@@ -18,10 +20,9 @@ Eigen
 Header-only linear algebra library. Eigen is primarily licensed under the
 Mozilla Public License 2.0 and contains files under additional compatible
 licenses.
-FEMaster is currently built against Eigen development headers reporting
-version 3.4.90.
-Upstream source (current master):
-  https://gitlab.com/libeigen/eigen/-/tree/master
+FEMaster release builds currently use Eigen 5.0.1.
+Upstream source:
+  https://gitlab.com/libeigen/eigen
 License and notice files:
   licenses/eigen-COPYING.README.txt
   licenses/eigen-COPYING.MPL2.txt
@@ -50,5 +51,12 @@ License, notice, and redistributable-list files:
   licenses/intel-compiler-EULA.rtf
   licenses/intel-openmp-third-party-programs.txt
   licenses/intel-compiler-redistributables.txt
+
+Apple Accelerate
+----------------
+Accelerate-enabled macOS builds link against the Apple Accelerate system
+framework for sparse linear algebra. Accelerate is supplied by macOS and the
+Apple SDK and is not distributed with FEMaster. No Apple framework binaries or
+license files are included in FEMaster distributions.
 
 No endorsement by any third-party project or vendor is implied.

--- a/src/solve/eigval/solve_eigval_shiftinvert_op_general.h
+++ b/src/solve/eigval/solve_eigval_shiftinvert_op_general.h
@@ -1,107 +1,98 @@
 /**
  * @file solve_eigval_shiftinvert_op_general.h
- * @brief Spectra-compatible operator: y = (A - σ B)^{-1} x for symmetric A,B.
+ * @brief Defines the Spectra shift-invert operator for generalized symmetric eigenproblems.
  *
- * @details
- * This operator is used by Spectra’s generalized shift–invert solvers:
- * ShiftInvert, Buckling, and Cayley. It maintains a cached factorization of
- * (A - σ B) and only re-factorizes when σ changes.
+ * The operator applies
  *
- * Backends:
- *   - If USE_MKL is defined: uses MKL PardisoLDLT.
- *   - Otherwise: uses Eigen SimplicialLDLT.
+ *     y = (A - sigma B)^-1 x
  *
- * Threading:
- *   - When built with MKL, the MKL thread count is set from
- *     global_config.max_threads inside perform_op().
+ * for Spectra's generalized shift-invert, buckling and Cayley formulations.
+ * The shifted matrix is factorized lazily and the factorization is cached while
+ * the shift remains unchanged, so repeated operator applications only perform
+ * sparse triangular solves.
  *
- * Usage pattern with Spectra:
- *   - Spectra calls perform_op() many times with constant σ per solve, so
- *     caching the factorization is critical for performance.
+ * The sparse factorization backend follows the FEMaster CPU configuration:
+ * Intel oneMKL uses PardisoLDLT, Apple Accelerate uses AccelerateLDLT and the
+ * portable fallback uses Eigen SimplicialLDLT. Spectra owns the eigensolver
+ * iteration while this class is responsible only for the shifted linear solve.
  *
- * @author
- *   Created by Finn Eggers (c) <finn.eggers@rwth-aachen.de>
- *   All rights reserved.
- * @date Created on 19.09.2025
+ * @author Finn Eggers
+ * @date 19.09.2025
  */
 
 #pragma once
 
 #include "../../core/types_eig.h"
+
 #include <Eigen/SparseCore>
 
-#ifndef USE_MKL
-  #include <Eigen/SparseCholesky>     // SimplicialLDLT
+#if defined(USE_MKL)
+#include "../../core/config.h"
+#include <Eigen/PardisoSupport>
+#include <mkl.h>
+#elif defined(USE_ACCELERATE)
+#include <Eigen/AccelerateSupport>
 #else
-  #include <Eigen/PardisoSupport>     // PardisoLDLT
-  #include "../../core/config.h"         // global_config.max_threads
-  #include <mkl.h>
+#include <Eigen/SparseCholesky>
 #endif
 
-#include <limits>   // std::numeric_limits
+#include <limits>
 
 namespace fem::solver {
 
 /**
- * @class ShiftInvertOpGeneral
- * @brief Applies y = (A - σ B)^{-1} x with cached factorization.
+ * @brief Spectra operator for generalized symmetric shift-invert eigenvalue solves.
+ *
+ * The class stores references to the symmetric matrices of the generalized
+ * eigenproblem and the active spectral shift. A factorization of
+ * `A - sigma B` is created on demand and remains valid until `set_shift()`
+ * changes the requested shift.
+ *
+ * `perform_op()` therefore has the cost of a sparse solve during the regular
+ * Spectra iteration and only triggers a new factorization after a shift change.
+ * The concrete LDLT implementation is selected at compile time from oneMKL,
+ * Apple Accelerate or Eigen.
  */
 class ShiftInvertOpGeneral {
 public:
     using Scalar = Precision;
 
-    /**
-     * @brief Construct with matrices A,B and initial shift σ.
-     * @param A     Reference to symmetric matrix A (kept by reference).
-     * @param B     Reference to symmetric matrix B (kept by reference).
-     * @param sigma Initial shift value.
-     */
-    ShiftInvertOpGeneral(const SparseMatrix& A,
-                         const SparseMatrix& B,
-                         Scalar sigma);
-
-    /** @return number of rows (equals A.rows()). */
-    int rows() const;
-
-    /** @return number of columns (equals A.cols()). */
-    int cols() const;
-
-    /**
-     * @brief Update the shift σ. The next apply will re-factorize.
-     * @param sigma New shift value.
-     */
-    void set_shift(const Scalar& sigma);
-
-    /**
-     * @brief Compute y = (A - σ B)^{-1} x.
-     * @param x_in  Pointer to input vector x (size = rows()).
-     * @param y_out Pointer to output vector y (size = rows()).
-     */
-    void perform_op(const Scalar* x_in, Scalar* y_out) const;
-
 private:
-    // Matrix A (by reference).
+    // Symmetric matrices kept by reference for the complete Spectra solve
     const SparseMatrix& _A_ref;
-
-    // Matrix B (by reference).
     const SparseMatrix& _B_ref;
 
-    // Target shift σ requested by the solver.
-    Scalar _sigma{0};
+    // Requested shift and the shift represented by the cached factorization
+    Scalar         _sigma      = Scalar(0);
+    mutable Scalar _sigma_fact = std::numeric_limits<Scalar>::quiet_NaN();
 
-    // Shift value that the cached factorization currently corresponds to.
-    // Initialized to NaN to force the first factorization.
-    mutable Scalar _sigma_fact{std::numeric_limits<Scalar>::quiet_NaN()};
-
-#ifdef USE_MKL
-    // MKL backend factorization object (LDLT of (A - σ B)).
+    // Cached factorization of A - sigma B
+#if defined(USE_MKL)
     mutable Eigen::PardisoLDLT<SparseMatrix> _ldl;
+#elif defined(USE_ACCELERATE)
+    mutable Eigen::AccelerateLDLT<SparseMatrix> _ldl;
 #else
-    // Eigen backend factorization object (SimplicialLDLT of (A - σ B)).
     mutable Eigen::SimplicialLDLT<SparseMatrix> _ldl;
 #endif
 
-    // Ensure a valid factorization exists for the current _sigma.
+public:
+    // Construction
+    ShiftInvertOpGeneral(const SparseMatrix& A, const SparseMatrix& B, Scalar sigma);
+
+    // Spectra operator dimensions
+    int rows() const;
+    int cols() const;
+
+    // Shift control. Changing the shift invalidates the cached factorization
+    // logically; the new factorization is built lazily on the next application.
+    void set_shift(const Scalar& sigma);
+
+    // Apply the inverse shifted operator to one Spectra vector
+    void perform_op(const Scalar* x_in, Scalar* y_out) const;
+
+private:
+    // Refresh the cached factorization when it does not represent the active shift
     void _factorize_if_needed() const;
 };
+
 } // namespace fem::solver

--- a/src/solve/eigval/solve_eigval_shiftinvert_op_simple.h
+++ b/src/solve/eigval/solve_eigval_shiftinvert_op_simple.h
@@ -1,101 +1,95 @@
 /**
  * @file solve_eigval_shiftinvert_op_simple.h
- * @brief Spectra-compatible operator: y = (A - σ I)^{-1} x for symmetric A.
+ * @brief Defines the Spectra shift-invert operator for standard symmetric eigenproblems.
  *
- * @details
- * This operator is used by Spectra’s shift–invert solvers for the simple
- * eigval problem A x = λ x. It maintains a cached factorization of (A - σ I)
- * and only re-factorizes when the shift σ changes.
+ * The operator applies
  *
- * Backends:
- *   - If USE_MKL is defined: uses MKL PardisoLDLT.
- *   - Otherwise: uses Eigen SimplicialLDLT.
+ *     y = (A - sigma I)^-1 x
  *
- * Threading:
- *   - When built with MKL, the MKL thread count is set from
- *     global_config.max_threads inside perform_op().
+ * during Spectra iterations. The shifted matrix is factorized lazily and the
+ * factorization is cached while the shift remains unchanged, so repeated
+ * operator applications only perform sparse triangular solves.
  *
- * Usage pattern with Spectra:
- *   - Spectra calls perform_op() many times (≈ ncv per restart). σ is constant
- *     throughout a solve, so caching the factorization saves a lot of time.
+ * The sparse factorization backend follows the FEMaster CPU configuration:
+ * Intel oneMKL uses PardisoLDLT, Apple Accelerate uses AccelerateLDLT and the
+ * portable fallback uses Eigen SimplicialLDLT. Spectra owns the iteration
+ * strategy while this class is responsible only for the shifted linear solve.
  *
- * @author
- *   Created by Finn Eggers (c) <finn.eggers@rwth-aachen.de>
- *   All rights reserved.
- * @date Created on 19.09.2025
+ * @author Finn Eggers
+ * @date 19.09.2025
  */
 
 #pragma once
 
 #include "../../core/types_eig.h"
+
 #include <Eigen/SparseCore>
 
-#ifndef USE_MKL
-  #include <Eigen/SparseCholesky>     // SimplicialLDLT
+#if defined(USE_MKL)
+#include "../../core/config.h"
+#include <Eigen/PardisoSupport>
+#include <mkl.h>
+#elif defined(USE_ACCELERATE)
+#include <Eigen/AccelerateSupport>
 #else
-  #include <Eigen/PardisoSupport>     // PardisoLDLT
-  #include "../../core/config.h"         // global_config.max_threads
-  #include <mkl.h>
+#include <Eigen/SparseCholesky>
 #endif
 
-#include <limits>   // std::numeric_limits
+#include <limits>
 
 namespace fem::solver {
 
 /**
- * @class ShiftInvertOpSimple
- * @brief Applies y = (A - σ I)^{-1} x with cached factorization.
+ * @brief Spectra operator for standard symmetric shift-invert eigenvalue solves.
+ *
+ * The class stores a reference to the symmetric system matrix and the active
+ * spectral shift. A factorization of `A - sigma I` is created on demand and
+ * remains valid until `set_shift()` changes the requested shift.
+ *
+ * `perform_op()` therefore has the cost of a sparse solve during the regular
+ * Spectra iteration and only triggers a new factorization after a shift change.
+ * The concrete LDLT implementation is selected at compile time from oneMKL,
+ * Apple Accelerate or Eigen.
  */
 class ShiftInvertOpSimple {
 public:
     using Scalar = Precision;
 
-    /**
-     * @brief Construct with matrix A and initial shift σ.
-     * @param A     Reference to symmetric matrix A (kept by reference).
-     * @param sigma Initial shift value.
-     */
-    ShiftInvertOpSimple(const SparseMatrix& A, Scalar sigma);
-
-    /** @return number of rows (equals A.rows()). */
-    int rows() const;
-
-    /** @return number of columns (equals A.cols()). */
-    int cols() const;
-
-    /**
-     * @brief Update the shift σ. The next apply will re-factorize.
-     * @param sigma New shift value.
-     */
-    void set_shift(const Scalar& sigma);
-
-    /**
-     * @brief Compute y = (A - σ I)^{-1} x.
-     * @param x_in  Pointer to input vector x (size = rows()).
-     * @param y_out Pointer to output vector y (size = rows()).
-     */
-    void perform_op(const Scalar* x_in, Scalar* y_out) const;
-
 private:
-    // Original symmetric matrix A (by reference).
+    // Symmetric system matrix kept by reference for the complete Spectra solve
     const SparseMatrix& _A_ref;
 
-    // Target shift σ requested by the solver.
-    Scalar _sigma{0};
+    // Requested shift and the shift represented by the cached factorization
+    Scalar         _sigma      = Scalar(0);
+    mutable Scalar _sigma_fact = std::numeric_limits<Scalar>::quiet_NaN();
 
-    // Shift value that the cached factorization currently corresponds to.
-    // Initialized to NaN to force the first factorization.
-    mutable Scalar _sigma_fact{std::numeric_limits<Scalar>::quiet_NaN()};
-
-#ifdef USE_MKL
-    // MKL backend factorization object (LDLT of (A - σ I)).
+    // Cached factorization of A - sigma I
+#if defined(USE_MKL)
     mutable Eigen::PardisoLDLT<SparseMatrix> _ldl;
+#elif defined(USE_ACCELERATE)
+    mutable Eigen::AccelerateLDLT<SparseMatrix> _ldl;
 #else
-    // Eigen backend factorization object (SimplicialLDLT of (A - σ I)).
     mutable Eigen::SimplicialLDLT<SparseMatrix> _ldl;
 #endif
 
-    // Ensure a valid factorization exists for the current _sigma.
+public:
+    // Construction
+    ShiftInvertOpSimple(const SparseMatrix& A, Scalar sigma);
+
+    // Spectra operator dimensions
+    int rows() const;
+    int cols() const;
+
+    // Shift control. Changing the shift invalidates the cached factorization
+    // logically; the new factorization is built lazily on the next application.
+    void set_shift(const Scalar& sigma);
+
+    // Apply the inverse shifted operator to one Spectra vector
+    void perform_op(const Scalar* x_in, Scalar* y_out) const;
+
+private:
+    // Refresh the cached factorization when it does not represent the active shift
     void _factorize_if_needed() const;
 };
+
 } // namespace fem::solver

--- a/src/solve/get_solver_name.cpp
+++ b/src/solve/get_solver_name.cpp
@@ -2,7 +2,9 @@
 
 namespace fem::solver {
 
-std::string get_solver_name(SolverDevice device, SolverMethod method) {
+std::string get_solver_name(SolverDevice device,
+                            SolverMethod method,
+                            DirectSolverMatrixType matrix_type) {
 #ifndef SUPPORT_GPU
     device = CPU;
 #endif
@@ -22,9 +24,17 @@ std::string get_solver_name(SolverDevice device, SolverMethod method) {
     }
 
 #ifdef USE_MKL
-    return "CPU DIRECT MKL PardisoLDLT";
+    return matrix_type == DirectSolverMatrixType::General
+        ? "CPU DIRECT MKL PardisoLU"
+        : "CPU DIRECT MKL PardisoLDLT";
+#elif defined(USE_ACCELERATE)
+    return matrix_type == DirectSolverMatrixType::General
+        ? "CPU DIRECT Eigen SparseLU"
+        : "CPU DIRECT Apple Accelerate LDLT";
 #else
-    return "CPU DIRECT Eigen SimplicialLDLT";
+    return matrix_type == DirectSolverMatrixType::General
+        ? "CPU DIRECT Eigen SparseLU"
+        : "CPU DIRECT Eigen SimplicialLDLT";
 #endif
 }
 

--- a/src/solve/get_solver_name.h
+++ b/src/solve/get_solver_name.h
@@ -2,11 +2,14 @@
 
 #include "solve_device.h"
 #include "solve_method.h"
+#include "sparse/solve_sparse_direct.h"
 
 #include <string>
 
 namespace fem::solver {
 
-std::string get_solver_name(SolverDevice device, SolverMethod method);
+std::string get_solver_name(SolverDevice device,
+                            SolverMethod method,
+                            DirectSolverMatrixType matrix_type = DirectSolverMatrixType::SPD);
 
 } // namespace fem::solver

--- a/src/solve/sparse/solve_sparse_direct.cpp
+++ b/src/solve/sparse/solve_sparse_direct.cpp
@@ -21,7 +21,7 @@ DynamicMatrix solve_direct(SolverDevice device,
     logging::info(true, "");
     logging::info(true, "Solving system with N=", mat.cols(), " nnz=", mat.nonZeros(),
                   " nrhs=", rhs.cols(),
-                  " using ", get_solver_name(device, DIRECT),
+                  " using ", get_solver_name(device, DIRECT, matrix_type),
                   matrix_type == DirectSolverMatrixType::SPD ? " (SPD)" : " (general)");
 
     logging::up();

--- a/src/solve/sparse/solve_sparse_direct_cpu.cpp
+++ b/src/solve/sparse/solve_sparse_direct_cpu.cpp
@@ -1,102 +1,169 @@
+/**
+ * @file solve_sparse_direct_cpu.cpp
+ * @brief Implements CPU sparse direct solves for the FEMaster solver subsystem.
+ *
+ * General sparse systems are solved with LU factorization, while symmetric
+ * systems use LDLT. The concrete CPU backend is selected at compile time:
+ * Intel oneMKL uses PARDISO, Apple Accelerate is used for symmetric sparse
+ * systems, and the portable fallback uses Eigen's native sparse solvers.
+ *
+ * Accelerate-enabled builds retain Eigen SparseLU for general nonsymmetric
+ * matrices because Eigen only exposes Accelerate wrappers for symmetric and QR
+ * factorizations. This keeps the general solve path portable across Apple SDK
+ * versions while still accelerating the dominant symmetric FEM systems.
+ *
+ * Failed primary factorizations fall back to Eigen SparseQR so the established
+ * FEMaster recovery behavior is preserved across all CPU backends.
+ *
+ * @author Finn Eggers
+ * @date 23.08.2026
+ */
+
 #include "solve_sparse_direct.h"
 
 #include "../../core/logging.h"
 #include "../../core/timer.h"
-#include "../../core/config.h"
 
-#include <Eigen/SparseCholesky>
 #include <Eigen/SparseLU>
 #include <Eigen/SparseQR>
 
-#ifdef USE_MKL
+#if defined(USE_MKL)
+#include "../../core/config.h"
+#include <Eigen/PardisoSupport>
 #include <mkl.h>
+#elif defined(USE_ACCELERATE)
+#include <Eigen/AccelerateSupport>
+#else
+#include <Eigen/SparseCholesky>
 #endif
 
 namespace fem::solver::detail {
 
-DynamicMatrix solve_direct_cpu(SparseMatrix& mat,
-                               const DynamicMatrix& rhs,
-                               DirectSolverMatrixType matrix_type) {
-    Timer t {};
+/**
+ * Solves a sparse linear system on the CPU using the configured direct backend.
+ *
+ * General matrices are factorized with LU. Symmetric matrices are factorized
+ * with LDLT so the solver can exploit their structure while still supporting
+ * indefinite finite-element systems. If the selected factorization or solve
+ * fails, Eigen SparseQR is used as the common recovery path.
+ *
+ * Accelerate-enabled builds use Eigen SparseLU for general matrices and
+ * AccelerateLDLT for symmetric matrices. The latter delegates the factorization
+ * and solve to Apple's sparse solver implementation while preserving Eigen's
+ * sparse matrix interface.
+ *
+ * @param mat Sparse system matrix. Accelerate may compress its storage in place
+ *            without changing its numerical entries.
+ * @param rhs Dense right-hand-side matrix. Multiple columns are solved together.
+ * @param matrix_type Structural matrix type used to select LU or LDLT.
+ * @return Dense matrix containing the solution columns.
+ */
+DynamicMatrix solve_direct_cpu(SparseMatrix& mat, const DynamicMatrix& rhs, DirectSolverMatrixType matrix_type) {
+    Timer t{};
     t.start();
 
+    // General matrices require an LU factorization because no symmetry can be assumed
     if (matrix_type == DirectSolverMatrixType::General) {
-        DynamicMatrix sol;
+        DynamicMatrix sol{};
+        bool          success = false;
 
-#ifdef USE_MKL
-        logging::info(true, "Using MKL PardisoLU solver");
-        Eigen::PardisoLU<SparseMatrix> solver {};
+#if defined(USE_MKL)
+        // Factorize and solve the general system with PARDISO LU
+        Eigen::PardisoLU<SparseMatrix> solver{};
         solver.compute(mat);
+
         if (solver.info() == Eigen::Success) {
-            sol = solver.solve(rhs);
+            sol     = solver.solve(rhs);
+            success = solver.info() == Eigen::Success;
         }
 #else
-        logging::info(true, "Using Eigen SparseLU solver");
-        Eigen::SparseLU<SparseMatrix, Eigen::COLAMDOrdering<int>> solver {};
+        // Keep the portable Eigen LU path for general matrices on Apple and fallback builds
+        Eigen::SparseLU<SparseMatrix, Eigen::COLAMDOrdering<int>> solver{};
         solver.compute(mat);
+
         if (solver.info() == Eigen::Success) {
-            sol = solver.solve(rhs);
+            sol     = solver.solve(rhs);
+            success = solver.info() == Eigen::Success;
         }
 #endif
 
-        if (solver.info() != Eigen::Success) {
-            logging::warning(false,
-                "General sparse LU failed; falling back to SparseQR");
+        // Recover from a failed LU factorization or solve with the common QR fallback
+        if (!success) {
+            logging::warning(false, "General sparse LU failed; falling back to SparseQR");
+
             Eigen::SparseQR<SparseMatrix, Eigen::COLAMDOrdering<int>> qr(mat);
             qr.compute(mat);
             sol = qr.solve(rhs);
+
             logging::error(qr.info() == Eigen::Success,
-                           "Solving general sparse system failed with SparseQR");
+                "Solving general sparse system failed with SparseQR");
         }
 
+        // Report the solve time and relative residual
         t.stop();
         logging::info(true, "Solving finished");
-        logging::info(true, "Elapsed time: " + std::to_string(t.elapsed()) + " ms");
-        logging::info(true, "residual    : ", (rhs - mat * sol).norm() / rhs.norm());
+        logging::info(true, "Elapsed time : ", t.elapsed(), " ms");
+        logging::info(true, "Residual     : ", (rhs - mat * sol).norm() / rhs.norm());
         return sol;
     }
 
-#ifdef USE_MKL
+    // Symmetric systems use LDLT so the factorization can exploit matrix symmetry
+    DynamicMatrix sol{};
+    bool          success = false;
+
+#if defined(USE_MKL)
+    // Configure PARDISO threading from the global FEMaster solver configuration
     mkl_set_num_threads(global_config.max_threads);
-    int mkl_max_threads = mkl_get_max_threads();
-    logging::info(true, "MKL max threads: ", mkl_max_threads);
+    const int mkl_max_threads = mkl_get_max_threads();
 
-    logging::info(true, "Using MKL PardisoLDLT solver");
-    Eigen::PardisoLDLT<SparseMatrix> solver {};
+    logging::info(true, "MKL max threads          : ", mkl_max_threads);
 
+    Eigen::PardisoLDLT<SparseMatrix> solver{};
     solver.compute(mat);
-    logging::warning(solver.info() == Eigen::Success, "Decomposition failed with PardisoLDLT");
-    DynamicMatrix sol = solver.solve(rhs);
 
-    if (solver.info() != Eigen::Success) {
-        logging::warning(true, "Solving failed with PardisoLDLT");
-        Eigen::SparseQR<SparseMatrix, Eigen::COLAMDOrdering<int>> qr(mat);
-        qr.compute(mat);
-        sol = qr.solve(rhs);
-        logging::error(qr.info() == Eigen::Success, "Solving failed with SparseQR");
+    if (solver.info() == Eigen::Success) {
+        sol     = solver.solve(rhs);
+        success = solver.info() == Eigen::Success;
+    }
+#elif defined(USE_ACCELERATE)
+    // Eigen exposes Accelerate's symmetric sparse factorization directly
+    mat.makeCompressed();
+
+    Eigen::AccelerateLDLT<SparseMatrix> solver{};
+    solver.compute(mat);
+
+    if (solver.info() == Eigen::Success) {
+        sol     = solver.solve(rhs);
+        success = solver.info() == Eigen::Success;
     }
 #else
-    logging::info(true, "Using Eigen SimplicialLDLT solver");
-
-    Eigen::SimplicialLDLT<SparseMatrix> solver {};
+    // Use Eigen's portable symmetric factorization when no native backend is enabled
+    Eigen::SimplicialLDLT<SparseMatrix> solver{};
     solver.compute(mat);
-    DynamicMatrix sol;
+
     if (solver.info() == Eigen::Success) {
-        sol = solver.solve(rhs);
-    }
-    if (solver.info() != Eigen::Success) {
-        logging::warning(true, "SimplicialLDLT failed; falling back to SparseQR");
-        Eigen::SparseQR<SparseMatrix, Eigen::COLAMDOrdering<int>> qr(mat);
-        qr.compute(mat);
-        sol = qr.solve(rhs);
-        logging::error(qr.info() == Eigen::Success, "Solving failed with SparseQR");
+        sol     = solver.solve(rhs);
+        success = solver.info() == Eigen::Success;
     }
 #endif
 
+    // Recover from a failed LDLT factorization or solve with the common QR fallback
+    if (!success) {
+        logging::warning(false, "Sparse LDLT failed; falling back to SparseQR");
+
+        Eigen::SparseQR<SparseMatrix, Eigen::COLAMDOrdering<int>> qr(mat);
+        qr.compute(mat);
+        sol = qr.solve(rhs);
+
+        logging::error(qr.info() == Eigen::Success,
+            "Solving sparse system failed with SparseQR");
+    }
+
+    // Report the solve time and relative residual
     t.stop();
     logging::info(true, "Solving finished");
-    logging::info(true, "Elapsed time: " + std::to_string(t.elapsed()) + " ms");
-    logging::info(true, "residual    : ", (rhs - mat * sol).norm() / (rhs.norm()));
+    logging::info(true, "Elapsed time : ", t.elapsed(), " ms");
+    logging::info(true, "Residual     : ", (rhs - mat * sol).norm() / rhs.norm());
 
     return sol;
 }


### PR DESCRIPTION
## Summary
- add Apple Accelerate sparse LDLT support for symmetric CPU solves
- use Accelerate LDLT in the cached Spectra shift-invert operators
- retain Eigen `SparseLU` for general nonsymmetric systems on macOS
- add four explicit macOS presets: `macos`, `macos-accelerate`, `macos-omp`, and `macos-omp-accelerate`
- keep plain macOS presets on the Eigen sparse fallback
- document Apple Accelerate in `THIRD_PARTY_NOTICES.txt`
- update modified C++ files to the FEMaster code-style conventions

No new FEMaster classes, helper functions, or source files are introduced.