### PR TITLE
Use scope-aware variants for assembly sets

### DIFF
--- a/src/io/dsl/command.h
+++ b/src/io/dsl/command.h
@@ -12,7 +12,8 @@
  *    variant whose condition evaluates to true (or that has no condition) and then
  *    executes its segments;
  *  - register **entry** and **exit hooks** (`on_enter(...)`, `on_exit(...)`) that are
- *    executed when the command is entered or left in the parsing scope hierarchy.
+ *    executed when the command is entered or left in the parsing scope hierarchy;
+ *  - mark a command as a parent terminator (`closes_parent()`).
  *
  * Typical usage:
  * @code
@@ -38,6 +39,8 @@
  *    selected parent scope.
  *  - `on_exit` is executed when the command scope leaves (e.g. next command climbs up
  *    the scope stack or at end-of-file if still active).
+ *  - A command marked with `closes_parent()` is processed under its admitted parent and
+ *    then removes that parent instead of becoming a new scope itself.
  *
  * @see variant.h
  * @see condition.h
@@ -78,6 +81,9 @@ struct Command {
 
     /** Stage-local execution mode. */
     ActiveMode active_ = ActiveMode::Active;
+
+    /** Whether successful processing closes the admitted parent scope. */
+    bool closes_parent_ = false;
 
     /** Optional hook executed once with the selected parent and command keys. */
     std::function<void(const ParentInfo&, const Keys&)> on_enter_;
@@ -139,6 +145,20 @@ struct Command {
      */
     Command& active(ActiveMode mode) {
         active_ = mode;
+        return *this;
+    }
+
+    /**
+     * @brief Marks this command as a terminator for its admitted parent scope.
+     *
+     * The command is validated and processed normally under the selected parent. After
+     * successful processing the engine pops that parent, firing its `on_exit` hook, and
+     * does not push this command as a new scope.
+     *
+     * @return Reference to `*this` for fluent chaining.
+     */
+    Command& closes_parent() {
+        closes_parent_ = true;
         return *this;
     }
 

--- a/src/io/dsl/command.h
+++ b/src/io/dsl/command.h
@@ -34,7 +34,8 @@
  *  - If no admission condition is set (`allow_if` never called), `admit_` defaults to
  *    `Condition{}` which is the `Always` condition (i.e., admissible under any parent).
  *  - Variants are checked in the order they were added; the first matching one is used.
- *  - `on_enter` is executed before segments of the variant run.
+ *  - `on_enter` is executed before segments of the variant run and may inspect the
+ *    selected parent scope.
  *  - `on_exit` is executed when the command scope leaves (e.g. next command climbs up
  *    the scope stack or at end-of-file if still active).
  *
@@ -78,8 +79,8 @@ struct Command {
     /** Stage-local execution mode. */
     ActiveMode active_ = ActiveMode::Active;
 
-    /** Optional hook executed once when the command is entered (before segments run). */
-    std::function<void(const Keys&)> on_enter_;
+    /** Optional hook executed once with the selected parent and command keys. */
+    std::function<void(const ParentInfo&, const Keys&)> on_enter_;
 
     /** Optional hook executed when the command's scope is exited. */
     std::function<void(const Keys&)> on_exit_;
@@ -142,16 +143,33 @@ struct Command {
     }
 
     /**
-     * @brief Registers a hook invoked once per keyword before any variant segments.
+     * @brief Registers a parent-aware hook invoked before any variant segments.
      *
-     * Typical use-cases: activate target sets, allocate per-command context, etc.
-     * The hook receives the keyword-line keys (parsed via `Keys::from_keyword_line`).
+     * The parent is the scope selected by command admission after the engine has
+     * climbed and popped the scope stack. The keys are the normalized arguments of
+     * the current keyword line.
+     *
+     * @param fn Callback taking the selected parent and command keyword keys.
+     * @return Reference to `*this` for fluent chaining.
+     */
+    Command& on_enter(std::function<void(const ParentInfo&, const Keys&)> fn) {
+        on_enter_ = std::move(fn);
+        return *this;
+    }
+
+    /**
+     * @brief Registers a key-only hook invoked before any variant segments.
+     *
+     * This overload preserves the compact callback form for commands that do not
+     * depend on their parent scope.
      *
      * @param fn Callback taking the command's keyword keys.
      * @return Reference to `*this` for fluent chaining.
      */
     Command& on_enter(std::function<void(const Keys&)> fn) {
-        on_enter_ = std::move(fn);
+        on_enter_ = [fn = std::move(fn)](const ParentInfo&, const Keys& keys) {
+            fn(keys);
+        };
         return *this;
     }
 

--- a/src/io/dsl/engine.h
+++ b/src/io/dsl/engine.h
@@ -310,10 +310,10 @@ public:
             if (!consume_only) {
                 logging::info("Processing command: *", cmd);
 
-                // on_enter runs only after a variant was selected, but before segment callbacks.
+                // Run command setup with the selected parent before segment callbacks
                 if (spec->on_enter_) {
                     try {
-                        spec->on_enter_(self_keys);
+                        spec->on_enter_(scope.back(), self_keys);
                     } catch (const std::exception& e) {
                         throw_at(ln.location(), e.what());
                     }

--- a/src/io/dsl/engine.h
+++ b/src/io/dsl/engine.h
@@ -15,7 +15,8 @@
  *          - Attempt to **admit** it against the current scope (climb upwards until allowed).
  *          - Choose the **highest-ranked fitting variant**.
  *          - Execute its **segments** according to their `LineRange` and `Pattern`.
- *          - Push this command as the new parent (scope goes “down”).
+ *          - Push this command as the new parent, or close the admitted parent for a
+ *            `closes_parent()` terminator.
  *
  * ## Variant selection (ranked trial & backtrack)
  *  - Variants whose conditions hold are ordered by descending `Variant::rank()`; ties keep
@@ -125,7 +126,7 @@ public:
      *      a. If command is unregistered → report an unknown keyword.
      *      b. If registered → climb scope upwards until the command is admitted.
      *      c. Try fitting variants in descending rank with backtracking.
-     *      d. Execute its segments and push the processed command as the new parent.
+     *      d. Execute its segments and either push the command or close its admitted parent.
      *  4. At EOF, call `on_exit` for **all scopes still open** (except ROOT).
      *
      * @param file Input file object providing normalized lines (with include support).
@@ -328,6 +329,15 @@ public:
                         }
                     }
                 }
+            }
+
+            // Terminators process normally, then close the admitted parent without becoming a scope
+            if (spec->closes_parent_) {
+                if (chosen_parent_index == 0) {
+                    throw_at(ln.location(), "Command '" + cmd + "' cannot close the ROOT scope");
+                }
+                pop_scope_to(static_cast<std::size_t>(chosen_parent_index));
+                continue;
             }
 
             // After successful processing, this keyword becomes the new parent (scope descends)

--- a/src/io/reader/commands/register_assembly.inl
+++ b/src/io/reader/commands/register_assembly.inl
@@ -1,41 +1,43 @@
 /**
  * @file register_assembly.inl
- * @brief Registers the ASSEMBLY scope.
+ * @brief Registers the ASSEMBLY input scope.
  *
- * FEMaster represents the assembly directly through `Model`, so this command
- * does not create a second assembly object. Instead it opens the grammar scope
- * and updates registry-local state used by node, element, set and surface
- * commands to distinguish assembly-level definitions from part-local data.
+ * FEMaster represents the assembly directly through `Model` and therefore does
+ * not create a separate assembly object. `ASSEMBLY` only introduces a grammar
+ * scope under which assembly-specific command variants may be selected.
  *
- * The shared scope flag belongs to one parser pass and is cleared by the
- * corresponding `ENDASSEMBLY` registration.
+ * Scope ownership remains entirely inside the DSL engine; no parallel parser
+ * flag is required.
  *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
-
-#include <memory>
 
 #include "../../dsl/condition.h"
 #include "../../dsl/keyword.h"
 
 namespace fem::io::reader::commands {
 
-inline void register_assembly(fem::io::dsl::Registry& registry,
-                              std::shared_ptr<bool> assembly_scope) {
-    registry.command("ASSEMBLY", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("ROOT"));
-        command.doc("Begin the assembly scope represented directly by Model.");
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the root-level `ASSEMBLY` grammar scope.
+ */
+inline void register_assembly(dsl::Registry& registry) {
+    registry.command("ASSEMBLY", [&](dsl::Command& command) {
+        // Restrict ASSEMBLY to the root scope
+        command.allow_if(dsl::Condition::parent_is("ROOT"));
+
+        // Define the optional assembly name accepted by the input format
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("NAME").optional("ASSEMBLY").doc("Optional assembly name")
         );
-        command.on_enter([assembly_scope](const fem::io::dsl::Keys&) {
-            *assembly_scope = true;
-        });
-        command.variant(fem::io::dsl::Variant::make());
+
+        // ASSEMBLY only introduces a grammar scope
+        command.variant(dsl::Variant::make());
     });
 }
 

--- a/src/io/reader/commands/register_element.inl
+++ b/src/io/reader/commands/register_element.inl
@@ -12,13 +12,12 @@
  * `Model::compile()`.
  *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
 
 #include <array>
-#include <memory>
 #include <string>
 #include <utility>
 
@@ -49,6 +48,8 @@
 
 namespace fem::io::reader::commands {
 
+namespace dsl = fem::io::dsl;
+
 template<class Elem, std::size_t N, std::size_t... I>
 inline void set_regular_element_impl(model::Model& model,
                                      ID id,
@@ -62,13 +63,17 @@ inline void set_regular_element(model::Model& model, ID id, const std::array<ID,
     set_regular_element_impl<Elem, N>(model, id, nodes, std::make_index_sequence<N>{});
 }
 
-inline void register_element(fem::io::dsl::Registry& registry,
-                             model::Model& model,
-                             std::shared_ptr<bool> assembly_scope) {
-    registry.command("ELEMENT", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+/**
+ * @brief Registers sparse finite-element connectivity before model compilation.
+ */
+inline void register_element(dsl::Registry& registry, model::Model& model) {
+    registry.command("ELEMENT", [&](dsl::Command& command) {
+        // Elements may be defined directly, inside a Part or inside the assembly scope
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+
+        // Define the destination element set and concrete element formulation
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("ELSET").optional("EALL")
                 .key("TYPE").required().allowed({
                     "C3D4", "C3D5", "C3D6", "C3D8", "C3D8R", "C3D10", "C3D15", "C3D20", "C3D20R",
@@ -76,24 +81,25 @@ inline void register_element(fem::io::dsl::Registry& registry,
                     "MITC3FRT", "MITC4FRT", "MITC6FRT", "MITC8FRT"
                 })
         );
-        command.on_enter([&model, assembly_scope](const fem::io::dsl::Keys& keys) {
+
+        // Prepare the active element set before processing connectivity rows
+        command.on_enter([&model](const dsl::Keys& keys) {
             logging::error(model._data != nullptr && !model._data->compiled,
                 "ELEMENT: elements cannot be added after compile()");
-            if (*assembly_scope) {
-                model._data->parts.activate(model::Model::DEFAULT_PART_NAME);
-            }
+
             const auto part = model._data->parts.get();
             logging::error(part != nullptr,
                 "ELEMENT: no active part is available");
+
             part->elem_sets.activate(keys.raw("ELSET"));
         });
 
 #define FEM_ADD_ELEMENT_VARIANT(KEY, ELEM, COUNT) \
-        command.variant(fem::io::dsl::Variant::make() \
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {KEY})) \
-            .segment(fem::io::dsl::Segment::make() \
-                .range(fem::io::dsl::LineRange{}.min(1)) \
-                .pattern(fem::io::dsl::Pattern::make() \
+        command.variant(dsl::Variant::make() \
+            .when(dsl::Condition::key_equals("TYPE", {KEY})) \
+            .segment(dsl::Segment::make() \
+                .range(dsl::LineRange{}.min(1)) \
+                .pattern(dsl::Pattern::make() \
                     .allow_multiline() \
                     .one<ID>().name("ID") \
                     .fixed<ID, COUNT>().name("N") \
@@ -104,6 +110,7 @@ inline void register_element(fem::io::dsl::Registry& registry,
             ) \
         );
 
+        // Register regular formulations with direct connectivity mapping
         FEM_ADD_ELEMENT_VARIANT("C3D4", C3D4, 4);
         FEM_ADD_ELEMENT_VARIANT("C3D6", C3D6, 6);
         FEM_ADD_ELEMENT_VARIANT("C3D8", C3D8, 8);
@@ -128,11 +135,12 @@ inline void register_element(fem::io::dsl::Registry& registry,
 
 #undef FEM_ADD_ELEMENT_VARIANT
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {"C3D5"}))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Expand the five-node pyramid into the supported degenerate C3D8 topology
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::key_equals("TYPE", {"C3D5"}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
                     .allow_multiline()
                     .one<ID>().name("ID")
                     .fixed<ID, 5>().name("N")

--- a/src/io/reader/commands/register_elset.inl
+++ b/src/io/reader/commands/register_elset.inl
@@ -3,25 +3,18 @@
  * @brief Registers part-local and assembly-level element sets.
  *
  * `ELSET` accepts explicit element or element-set references and generated
- * arithmetic ranges. String references are delegated to
- * `Model::add_elements_to_set()` so the same set-composition semantics apply
- * before and after compilation. Part-local definitions retain sparse element
- * IDs in the active Part, whereas assembly-level references may use optional
- * Instance qualification and are resolved through the compiled local-to-global
- * element maps.
+ * arithmetic ranges. Part/root variants retain sparse element identifiers in
+ * the active Part, while assembly variants are replayed after compilation and
+ * resolve optional Instance qualification through compiled element maps.
  *
- * `GENERATE` remains a numeric path because its arithmetic range already
- * provides element identifiers directly and does not require string-reference
- * interpretation.
- *
- * The completed `ElementRegion` is shared by section assignments, distributed
- * loads, output requests and other element-domain operations.
+ * Scope-dependent behavior is selected declaratively through DSL variants. No
+ * separate parser-level assembly flag is required.
  *
  * @see model::Model::add_elements_to_set
  * @see model::ElementRegion
  *
  * @author Finn Eggers
- * @date 24.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
@@ -36,93 +29,151 @@
 
 namespace fem::io::reader::commands {
 
-inline void register_elset(fem::io::dsl::Registry& registry,
-                           model::Model& model,
-                           std::shared_ptr<bool> assembly_scope) {
-    registry.command("ELSET", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the `ELSET` command for part-local and compiled assembly scopes.
+ */
+inline void register_elset(dsl::Registry& registry, model::Model& model) {
+    registry.command("ELSET", [&](dsl::Command& command) {
+        // Allow element sets in the unqualified root, part and assembly scopes
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
 
         struct Context {
-            bool assembly = false;
             std::string name;
             std::string instance;
-            model::ElementRegion::Ptr destination = nullptr;
         };
         auto ctx = std::make_shared<Context>();
 
+        // Define the set name, optional assembly Instance and generated-range mode
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("ELSET").alternative("NAME").required()
                 .key("INSTANCE").optional()
                 .flag("GENERATE")
         );
-        command.on_enter([&model, assembly_scope, ctx](const fem::io::dsl::Keys& keys) {
-            ctx->assembly    = *assembly_scope;
-            ctx->name        = keys.raw("ELSET");
-            ctx->instance    = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
-            ctx->destination = nullptr;
 
-            logging::error(ctx->assembly || ctx->instance.empty(),
-                "ELSET: INSTANCE is only valid at assembly level");
-
-            if (ctx->assembly) {
-                if (!model._data->compiled) return;
-                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
-                    "ELSET: instance ", ctx->instance, " is not defined");
-                ctx->destination = model._data->elem_sets.activate(ctx->name);
-            } else if (!model._data->compiled) {
-                const auto part = model._data->parts.get();
-                logging::error(part != nullptr,
-                    "ELSET: no active part is available");
-                ctx->destination = part->elem_sets.activate(ctx->name);
-            }
+        // Store keyword state shared by all data-layout variants
+        command.on_enter([ctx](const dsl::Keys& keys) {
+            ctx->name     = keys.raw("ELSET");
+            ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
         });
 
-        const std::string missing_token = "__MISSING__";
+        const auto part_scope     = dsl::Condition::parent_is({"ROOT", "PART"});
+        const auto assembly_scope = dsl::Condition::parent_is("ASSEMBLY");
+        const auto generated      = dsl::Condition::key_true("GENERATE");
+        const auto listed         = dsl::Condition::any_of({
+            dsl::Condition::negate(dsl::Condition::key_present("GENERATE")),
+            dsl::Condition::key_false("GENERATE")
+        });
 
-        command.variant(fem::io::dsl::Variant::make()
+        // Expand generated ranges directly into sparse part-local element identifiers
+        command.variant(dsl::Variant::make()
             .rank(10)
-            .when(fem::io::dsl::Condition::key_true("GENERATE"))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
-                    .one<fem::ID>().name("START")
-                    .one<fem::ID>().name("END")
-                    .one<fem::ID>().name("INC").on_missing(fem::ID{1}).on_empty(fem::ID{1})
+            .when(dsl::Condition::all_of({part_scope, generated}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
+                    .one<ID>().name("START")
+                    .one<ID>().name("END")
+                    .one<ID>().name("INC").on_missing(ID{1}).on_empty(ID{1})
                 )
-                .bind([&model, ctx](fem::ID first, fem::ID last, fem::ID inc) {
+                .bind([&model, ctx](ID first, ID last, ID inc) {
+                    logging::error(ctx->instance.empty(),
+                        "ELSET: INSTANCE is only valid at assembly level");
                     logging::error(inc != 0,
                         "ELSET/GENERATE: increment must not be zero");
-                    if (!ctx->destination) return;
+                    if (model._data->compiled) return;
                     if ((inc > 0 && first > last) || (inc < 0 && first < last)) return;
 
-                    for (fem::ID id = first;; id += inc) {
-                        const fem::ID value = ctx->assembly
-                            ? (ctx->instance.empty() ? model.compiled_element_id(id)
-                                                     : model.compiled_element_id(id, ctx->instance))
-                            : id;
-                        ctx->destination->add(value);
+                    const auto part = model._data->parts.get();
+                    logging::error(part != nullptr,
+                        "ELSET: no active part is available");
+                    const auto destination = part->elem_sets.activate(ctx->name);
 
-                        const fem::ID next = static_cast<fem::ID>(id + inc);
+                    for (ID id = first;; id += inc) {
+                        destination->add(id);
+
+                        const ID next = static_cast<ID>(id + inc);
                         if (inc > 0 ? next > last : next < last) break;
                     }
                 })
             )
         );
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::any_of({
-                fem::io::dsl::Condition::negate(fem::io::dsl::Condition::key_present("GENERATE")),
-                fem::io::dsl::Condition::key_false("GENERATE")
-            }))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(0))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Expand generated assembly ranges through the compiled Instance mapping
+        command.variant(dsl::Variant::make()
+            .rank(10)
+            .when(dsl::Condition::all_of({assembly_scope, generated}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
+                    .one<ID>().name("START")
+                    .one<ID>().name("END")
+                    .one<ID>().name("INC").on_missing(ID{1}).on_empty(ID{1})
+                )
+                .bind([&model, ctx](ID first, ID last, ID inc) {
+                    logging::error(inc != 0,
+                        "ELSET/GENERATE: increment must not be zero");
+                    if (!model._data->compiled) return;
+                    if ((inc > 0 && first > last) || (inc < 0 && first < last)) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "ELSET: instance ", ctx->instance, " is not defined");
+                    const auto destination = model._data->elem_sets.activate(ctx->name);
+
+                    for (ID id = first;; id += inc) {
+                        const ID value = ctx->instance.empty()
+                            ? model.compiled_element_id(id)
+                            : model.compiled_element_id(id, ctx->instance);
+                        destination->add(value);
+
+                        const ID next = static_cast<ID>(id + inc);
+                        if (inc > 0 ? next > last : next < last) break;
+                    }
+                })
+            )
+        );
+
+        const std::string missing_token = "__MISSING__";
+
+        // Resolve listed part-local element or element-set references in the active Part
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({part_scope, listed}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
                     .fixed<std::string, 32>().name("TARGET")
                         .on_missing(missing_token).on_empty(missing_token)
                 )
                 .bind([&model, ctx, missing_token](const std::array<std::string, 32>& targets) {
-                    if (!ctx->destination) return;
+                    logging::error(ctx->instance.empty(),
+                        "ELSET: INSTANCE is only valid at assembly level");
+                    if (model._data->compiled) return;
+
+                    for (const std::string& target : targets) {
+                        if (target == missing_token) continue;
+                        model.add_elements_to_set(ctx->name, target);
+                    }
+                })
+            )
+        );
+
+        // Resolve listed assembly references with optional Instance qualification
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({assembly_scope, listed}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
+                    .fixed<std::string, 32>().name("TARGET")
+                        .on_missing(missing_token).on_empty(missing_token)
+                )
+                .bind([&model, ctx, missing_token](const std::array<std::string, 32>& targets) {
+                    if (!model._data->compiled) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "ELSET: instance ", ctx->instance, " is not defined");
+
                     for (const std::string& target : targets) {
                         if (target == missing_token) continue;
                         model.add_elements_to_set(ctx->name, target, ctx->instance);

--- a/src/io/reader/commands/register_elset.inl
+++ b/src/io/reader/commands/register_elset.inl
@@ -53,10 +53,30 @@ inline void register_elset(dsl::Registry& registry, model::Model& model) {
                 .flag("GENERATE")
         );
 
-        // Store keyword state shared by all data-layout variants
-        command.on_enter([ctx](const dsl::Keys& keys) {
+        // Store keyword state and create the destination even for an empty listed set
+        command.on_enter([&model, ctx](const dsl::ParentInfo& parent, const dsl::Keys& keys) {
             ctx->name     = keys.raw("ELSET");
             ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
+
+            if (parent.command == "ASSEMBLY") {
+                if (!model._data->compiled) return;
+
+                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                    "ELSET: instance ", ctx->instance, " is not defined");
+
+                model._data->elem_sets.activate(ctx->name);
+                return;
+            }
+
+            logging::error(ctx->instance.empty(),
+                "ELSET: INSTANCE is only valid at assembly level");
+            if (model._data->compiled) return;
+
+            const auto part = model._data->parts.get();
+            logging::error(part != nullptr,
+                "ELSET: no active part is available");
+
+            part->elem_sets.activate(ctx->name);
         });
 
         const auto part_scope     = dsl::Condition::parent_is({"ROOT", "PART"});

--- a/src/io/reader/commands/register_end_assembly.inl
+++ b/src/io/reader/commands/register_end_assembly.inl
@@ -29,6 +29,7 @@ inline void register_end_assembly(dsl::Registry& registry) {
     registry.command("ENDASSEMBLY", [&](dsl::Command& command) {
         // ENDASSEMBLY is only valid for an active assembly scope
         command.allow_if(dsl::Condition::parent_is("ASSEMBLY"));
+        command.closes_parent();
 
         // The command only closes the grammar scope
         command.variant(dsl::Variant::make());

--- a/src/io/reader/commands/register_end_assembly.inl
+++ b/src/io/reader/commands/register_end_assembly.inl
@@ -2,36 +2,36 @@
  * @file register_end_assembly.inl
  * @brief Registers the ENDASSEMBLY scope terminator.
  *
- * `ENDASSEMBLY` closes the assembly grammar scope and clears the registry-local
- * flag shared with assembly-aware topology commands. The flag determines
- * whether sets, surfaces and other qualified definitions address compiled
- * assembly entities rather than active Part storage.
+ * `ENDASSEMBLY` closes the assembly grammar scope. FEMaster does not destroy or
+ * modify a separate assembly object because the assembled domain is represented
+ * directly by the persistent `Model`.
  *
- * No model object is destroyed when the scope ends because FEMaster represents
- * the assembly directly through the persistent `Model`.
+ * Scope ownership remains entirely inside the DSL engine; no parser-local flag
+ * needs to be cleared explicitly.
  *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
-
-#include <memory>
 
 #include "../../dsl/condition.h"
 #include "../../dsl/keyword.h"
 
 namespace fem::io::reader::commands {
 
-inline void register_end_assembly(fem::io::dsl::Registry& registry,
-                                  std::shared_ptr<bool> assembly_scope) {
-    registry.command("ENDASSEMBLY", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("ASSEMBLY"));
-        command.doc("Terminate the assembly scope.");
-        command.on_enter([assembly_scope](const fem::io::dsl::Keys&) {
-            *assembly_scope = false;
-        });
-        command.variant(fem::io::dsl::Variant::make());
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the `ENDASSEMBLY` grammar-scope terminator.
+ */
+inline void register_end_assembly(dsl::Registry& registry) {
+    registry.command("ENDASSEMBLY", [&](dsl::Command& command) {
+        // ENDASSEMBLY is only valid for an active assembly scope
+        command.allow_if(dsl::Condition::parent_is("ASSEMBLY"));
+
+        // The command only closes the grammar scope
+        command.variant(dsl::Variant::make());
     });
 }
 

--- a/src/io/reader/commands/register_end_instance.inl
+++ b/src/io/reader/commands/register_end_instance.inl
@@ -23,6 +23,7 @@ namespace fem::io::reader::commands {
 inline void register_end_instance(fem::io::dsl::Registry& registry) {
     registry.command("ENDINSTANCE", [&](fem::io::dsl::Command& command) {
         command.allow_if(fem::io::dsl::Condition::parent_is("INSTANCE"));
+        command.closes_parent();
         command.doc("Terminate the current instance scope.");
         command.variant(fem::io::dsl::Variant::make());
     });

--- a/src/io/reader/commands/register_end_part.inl
+++ b/src/io/reader/commands/register_end_part.inl
@@ -2,10 +2,10 @@
  * @file register_end_part.inl
  * @brief Registers the ENDPART scope terminator.
  *
- * `ENDPART` explicitly terminates an active reusable Part grammar scope. The
- * corresponding model-state transition belongs to the `PART` scope itself and
- * is performed by its exit hook, so explicit and implicit scope exits have the
- * same behavior.
+ * `ENDPART` is admitted at root level so the DSL engine climbs out of an active
+ * `PART` scope before processing the terminator. Popping the Part triggers its
+ * exit hook, which restores the model's default Part for both explicit and
+ * implicit scope exits.
  *
  * @author Finn Eggers
  * @date 19.08.2026
@@ -21,7 +21,7 @@ namespace fem::io::reader::commands {
 
 inline void register_end_part(fem::io::dsl::Registry& registry, model::Model&) {
     registry.command("ENDPART", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("PART"));
+        command.allow_if(fem::io::dsl::Condition::parent_is("ROOT"));
         command.doc("Terminate the current part definition.");
         command.variant(fem::io::dsl::Variant::make());
     });

--- a/src/io/reader/commands/register_end_part.inl
+++ b/src/io/reader/commands/register_end_part.inl
@@ -2,13 +2,10 @@
  * @file register_end_part.inl
  * @brief Registers the ENDPART scope terminator.
  *
- * `ENDPART` closes the active reusable Part definition and restores the model's
- * default part as the target for subsequent unqualified topology commands. The
- * transition is permitted only before model compilation because semantic Part
- * topology becomes immutable at the compile boundary.
- *
- * Scope admission is enforced by the DSL registry; this callback performs the
- * corresponding model-state transition.
+ * `ENDPART` explicitly terminates an active reusable Part grammar scope. The
+ * corresponding model-state transition belongs to the `PART` scope itself and
+ * is performed by its exit hook, so explicit and implicit scope exits have the
+ * same behavior.
  *
  * @author Finn Eggers
  * @date 19.08.2026
@@ -22,15 +19,10 @@
 
 namespace fem::io::reader::commands {
 
-inline void register_end_part(fem::io::dsl::Registry& registry, model::Model& model) {
+inline void register_end_part(fem::io::dsl::Registry& registry, model::Model&) {
     registry.command("ENDPART", [&](fem::io::dsl::Command& command) {
         command.allow_if(fem::io::dsl::Condition::parent_is("PART"));
         command.doc("Terminate the current part definition.");
-        command.on_enter([&model](const fem::io::dsl::Keys&) {
-            logging::error(model._data != nullptr && !model._data->compiled,
-                "ENDPART: part scope cannot change after compile()");
-            model._data->parts.activate(model::Model::DEFAULT_PART_NAME);
-        });
         command.variant(fem::io::dsl::Variant::make());
     });
 }

--- a/src/io/reader/commands/register_end_part.inl
+++ b/src/io/reader/commands/register_end_part.inl
@@ -2,10 +2,9 @@
  * @file register_end_part.inl
  * @brief Registers the ENDPART scope terminator.
  *
- * `ENDPART` is admitted at root level so the DSL engine climbs out of an active
- * `PART` scope before processing the terminator. Popping the Part triggers its
- * exit hook, which restores the model's default Part for both explicit and
- * implicit scope exits.
+ * `ENDPART` is valid only while a `PART` scope is active. The DSL terminator
+ * closes that admitted parent directly, which fires the Part exit hook and
+ * restores the model's default Part for explicit and implicit scope exits.
  *
  * @author Finn Eggers
  * @date 19.08.2026
@@ -21,7 +20,8 @@ namespace fem::io::reader::commands {
 
 inline void register_end_part(fem::io::dsl::Registry& registry, model::Model&) {
     registry.command("ENDPART", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("ROOT"));
+        command.allow_if(fem::io::dsl::Condition::parent_is("PART"));
+        command.closes_parent();
         command.doc("Terminate the current part definition.");
         command.variant(fem::io::dsl::Variant::make());
     });

--- a/src/io/reader/commands/register_node.inl
+++ b/src/io/reader/commands/register_node.inl
@@ -2,21 +2,16 @@
  * @file register_node.inl
  * @brief Registers part-local and unqualified assembly nodes.
  *
- * Node rows map sparse user identifiers to global Cartesian coordinates in the
- * currently active semantic Part. Root-level definitions are assigned to the
- * default part, while assembly-scope callbacks are coordinated separately
- * during the post-compile parser pass.
- *
- * This command retains the original identifiers and does not allocate dense
- * solver rows; that transformation belongs to `Model::compile()`.
+ * Node rows map sparse user identifiers to Cartesian coordinates in the
+ * currently active semantic Part. Root-level definitions use the model's
+ * default Part, while Instance expansion and dense global enumeration remain
+ * deferred to `Model::compile()`.
  *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
-
-#include <memory>
 
 #include "../../../model/model.h"
 #include "../../dsl/condition.h"
@@ -24,30 +19,39 @@
 
 namespace fem::io::reader::commands {
 
-inline void register_node(fem::io::dsl::Registry& registry,
-                          model::Model& model,
-                          std::shared_ptr<bool> assembly_scope) {
-    registry.command("NODE", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers sparse node definitions before model compilation.
+ */
+inline void register_node(dsl::Registry& registry, model::Model& model) {
+    registry.command("NODE", [&](dsl::Command& command) {
+        // Nodes may be defined directly, inside a Part or inside the assembly scope
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+
+        // Every node row is also inserted into the selected node set
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("NSET").optional("NALL")
         );
-        command.on_enter([&model, assembly_scope](const fem::io::dsl::Keys& keys) {
+
+        // Prepare the active node set before processing coordinate rows
+        command.on_enter([&model](const dsl::Keys& keys) {
             logging::error(model._data != nullptr && !model._data->compiled,
                 "NODE: nodes cannot be added after compile()");
-            if (*assembly_scope) {
-                model._data->parts.activate(model::Model::DEFAULT_PART_NAME);
-            }
+
             const auto part = model._data->parts.get();
             logging::error(part != nullptr,
                 "NODE: no active part is available");
+
             part->node_sets.activate(keys.raw("NSET"));
         });
-        command.variant(fem::io::dsl::Variant::make()
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(0))
-                .pattern(fem::io::dsl::Pattern::make()
+
+        // Read sparse node coordinates
+        command.variant(dsl::Variant::make()
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
                     .one<ID>().name("ID")
                     .one<Precision>().name("X").on_empty(Precision{0}).on_missing(Precision{0})
                     .one<Precision>().name("Y").on_empty(Precision{0}).on_missing(Precision{0})

--- a/src/io/reader/commands/register_nset.inl
+++ b/src/io/reader/commands/register_nset.inl
@@ -3,24 +3,18 @@
  * @brief Registers part-local and assembly-level node sets.
  *
  * `NSET` accepts explicit node or node-set references and generated arithmetic
- * ranges. String references are delegated to `Model::add_nodes_to_set()` so the
- * same set-composition semantics apply before and after compilation. Part-local
- * definitions retain sparse node IDs in the active Part, whereas assembly-level
- * references may use optional Instance qualification and are resolved through
- * the compiled local-to-global node maps.
+ * ranges. Part/root variants retain sparse node identifiers in the active Part,
+ * while assembly variants are replayed after compilation and resolve optional
+ * Instance qualification through compiled node maps.
  *
- * `GENERATE` remains a numeric path because its arithmetic range already
- * provides node identifiers directly and does not require string-reference
- * interpretation.
- *
- * The resulting `NodeRegion` is registered under its deck name for supports,
- * loads, couplings and later assembly commands.
+ * Scope-dependent behavior is selected declaratively through DSL variants. No
+ * separate parser-level assembly flag is required.
  *
  * @see model::Model::add_nodes_to_set
  * @see model::NodeRegion
  *
  * @author Finn Eggers
- * @date 24.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
@@ -35,93 +29,151 @@
 
 namespace fem::io::reader::commands {
 
-inline void register_nset(fem::io::dsl::Registry& registry,
-                          model::Model& model,
-                          std::shared_ptr<bool> assembly_scope) {
-    registry.command("NSET", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the `NSET` command for part-local and compiled assembly scopes.
+ */
+inline void register_nset(dsl::Registry& registry, model::Model& model) {
+    registry.command("NSET", [&](dsl::Command& command) {
+        // Allow node sets in the unqualified root, part and assembly scopes
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
 
         struct Context {
-            bool assembly = false;
             std::string name;
             std::string instance;
-            model::NodeRegion::Ptr destination = nullptr;
         };
         auto ctx = std::make_shared<Context>();
 
+        // Define the set name, optional assembly Instance and generated-range mode
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("NSET").alternative("NAME").required()
                 .key("INSTANCE").optional()
                 .flag("GENERATE")
         );
-        command.on_enter([&model, assembly_scope, ctx](const fem::io::dsl::Keys& keys) {
-            ctx->assembly    = *assembly_scope;
-            ctx->name        = keys.raw("NSET");
-            ctx->instance    = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
-            ctx->destination = nullptr;
 
-            logging::error(ctx->assembly || ctx->instance.empty(),
-                "NSET: INSTANCE is only valid at assembly level");
-
-            if (ctx->assembly) {
-                if (!model._data->compiled) return;
-                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
-                    "NSET: instance ", ctx->instance, " is not defined");
-                ctx->destination = model._data->node_sets.activate(ctx->name);
-            } else if (!model._data->compiled) {
-                const auto part = model._data->parts.get();
-                logging::error(part != nullptr,
-                    "NSET: no active part is available");
-                ctx->destination = part->node_sets.activate(ctx->name);
-            }
+        // Store keyword state shared by all data-layout variants
+        command.on_enter([ctx](const dsl::Keys& keys) {
+            ctx->name     = keys.raw("NSET");
+            ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
         });
 
-        const std::string missing_token = "__MISSING__";
+        const auto part_scope     = dsl::Condition::parent_is({"ROOT", "PART"});
+        const auto assembly_scope = dsl::Condition::parent_is("ASSEMBLY");
+        const auto generated      = dsl::Condition::key_true("GENERATE");
+        const auto listed         = dsl::Condition::any_of({
+            dsl::Condition::negate(dsl::Condition::key_present("GENERATE")),
+            dsl::Condition::key_false("GENERATE")
+        });
 
-        command.variant(fem::io::dsl::Variant::make()
+        // Expand generated ranges directly into sparse part-local node identifiers
+        command.variant(dsl::Variant::make()
             .rank(10)
-            .when(fem::io::dsl::Condition::key_true("GENERATE"))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
-                    .one<fem::ID>().name("START")
-                    .one<fem::ID>().name("END")
-                    .one<fem::ID>().name("INC").on_missing(fem::ID{1}).on_empty(fem::ID{1})
+            .when(dsl::Condition::all_of({part_scope, generated}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
+                    .one<ID>().name("START")
+                    .one<ID>().name("END")
+                    .one<ID>().name("INC").on_missing(ID{1}).on_empty(ID{1})
                 )
-                .bind([&model, ctx](fem::ID first, fem::ID last, fem::ID inc) {
+                .bind([&model, ctx](ID first, ID last, ID inc) {
+                    logging::error(ctx->instance.empty(),
+                        "NSET: INSTANCE is only valid at assembly level");
                     logging::error(inc != 0,
                         "NSET/GENERATE: increment must not be zero");
-                    if (!ctx->destination) return;
+                    if (model._data->compiled) return;
                     if ((inc > 0 && first > last) || (inc < 0 && first < last)) return;
 
-                    for (fem::ID id = first;; id += inc) {
-                        const fem::ID value = ctx->assembly
-                            ? (ctx->instance.empty() ? model.compiled_node_id(id)
-                                                     : model.compiled_node_id(id, ctx->instance))
-                            : id;
-                        ctx->destination->add(value);
+                    const auto part = model._data->parts.get();
+                    logging::error(part != nullptr,
+                        "NSET: no active part is available");
+                    const auto destination = part->node_sets.activate(ctx->name);
 
-                        const fem::ID next = static_cast<fem::ID>(id + inc);
+                    for (ID id = first;; id += inc) {
+                        destination->add(id);
+
+                        const ID next = static_cast<ID>(id + inc);
                         if (inc > 0 ? next > last : next < last) break;
                     }
                 })
             )
         );
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::any_of({
-                fem::io::dsl::Condition::negate(fem::io::dsl::Condition::key_present("GENERATE")),
-                fem::io::dsl::Condition::key_false("GENERATE")
-            }))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(0))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Expand generated assembly ranges through the compiled Instance mapping
+        command.variant(dsl::Variant::make()
+            .rank(10)
+            .when(dsl::Condition::all_of({assembly_scope, generated}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
+                    .one<ID>().name("START")
+                    .one<ID>().name("END")
+                    .one<ID>().name("INC").on_missing(ID{1}).on_empty(ID{1})
+                )
+                .bind([&model, ctx](ID first, ID last, ID inc) {
+                    logging::error(inc != 0,
+                        "NSET/GENERATE: increment must not be zero");
+                    if (!model._data->compiled) return;
+                    if ((inc > 0 && first > last) || (inc < 0 && first < last)) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "NSET: instance ", ctx->instance, " is not defined");
+                    const auto destination = model._data->node_sets.activate(ctx->name);
+
+                    for (ID id = first;; id += inc) {
+                        const ID value = ctx->instance.empty()
+                            ? model.compiled_node_id(id)
+                            : model.compiled_node_id(id, ctx->instance);
+                        destination->add(value);
+
+                        const ID next = static_cast<ID>(id + inc);
+                        if (inc > 0 ? next > last : next < last) break;
+                    }
+                })
+            )
+        );
+
+        const std::string missing_token = "__MISSING__";
+
+        // Resolve listed part-local node or node-set references in the active Part
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({part_scope, listed}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
                     .fixed<std::string, 32>().name("TARGET")
                         .on_missing(missing_token).on_empty(missing_token)
                 )
                 .bind([&model, ctx, missing_token](const std::array<std::string, 32>& targets) {
-                    if (!ctx->destination) return;
+                    logging::error(ctx->instance.empty(),
+                        "NSET: INSTANCE is only valid at assembly level");
+                    if (model._data->compiled) return;
+
+                    for (const std::string& target : targets) {
+                        if (target == missing_token) continue;
+                        model.add_nodes_to_set(ctx->name, target);
+                    }
+                })
+            )
+        );
+
+        // Resolve listed assembly references with optional Instance qualification
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({assembly_scope, listed}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
+                    .fixed<std::string, 32>().name("TARGET")
+                        .on_missing(missing_token).on_empty(missing_token)
+                )
+                .bind([&model, ctx, missing_token](const std::array<std::string, 32>& targets) {
+                    if (!model._data->compiled) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "NSET: instance ", ctx->instance, " is not defined");
+
                     for (const std::string& target : targets) {
                         if (target == missing_token) continue;
                         model.add_nodes_to_set(ctx->name, target, ctx->instance);

--- a/src/io/reader/commands/register_nset.inl
+++ b/src/io/reader/commands/register_nset.inl
@@ -53,10 +53,30 @@ inline void register_nset(dsl::Registry& registry, model::Model& model) {
                 .flag("GENERATE")
         );
 
-        // Store keyword state shared by all data-layout variants
-        command.on_enter([ctx](const dsl::Keys& keys) {
+        // Store keyword state and create the destination even for an empty listed set
+        command.on_enter([&model, ctx](const dsl::ParentInfo& parent, const dsl::Keys& keys) {
             ctx->name     = keys.raw("NSET");
             ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
+
+            if (parent.command == "ASSEMBLY") {
+                if (!model._data->compiled) return;
+
+                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                    "NSET: instance ", ctx->instance, " is not defined");
+
+                model._data->node_sets.activate(ctx->name);
+                return;
+            }
+
+            logging::error(ctx->instance.empty(),
+                "NSET: INSTANCE is only valid at assembly level");
+            if (model._data->compiled) return;
+
+            const auto part = model._data->parts.get();
+            logging::error(part != nullptr,
+                "NSET: no active part is available");
+
+            part->node_sets.activate(ctx->name);
         });
 
         const auto part_scope     = dsl::Condition::parent_is({"ROOT", "PART"});

--- a/src/io/reader/commands/register_part.inl
+++ b/src/io/reader/commands/register_part.inl
@@ -4,7 +4,9 @@
  *
  * A `PART` command creates and activates a named reusable semantic topology
  * container. Subsequent nodes, elements, local regions and section assignments
- * are stored against that Part until `ENDPART` restores the default context.
+ * are stored against that Part until the grammar scope is left, either
+ * explicitly through `ENDPART` or implicitly by a command admitted at a higher
+ * scope.
  *
  * Parts retain sparse local identifiers and remain independent of assembly
  * placement. Rigid transforms and dense global expansion are handled later by
@@ -32,6 +34,9 @@ inline void register_part(fem::io::dsl::Registry& registry, model::Model& model)
         );
         command.on_enter([&model](const fem::io::dsl::Keys& keys) {
             model.add_part(keys.raw("NAME"));
+        });
+        command.on_exit([&model](const fem::io::dsl::Keys&) {
+            model._data->parts.activate(model::Model::DEFAULT_PART_NAME);
         });
         command.variant(fem::io::dsl::Variant::make());
     });

--- a/src/io/reader/commands/register_sfset.inl
+++ b/src/io/reader/commands/register_sfset.inl
@@ -53,10 +53,30 @@ inline void register_sfset(dsl::Registry& registry, model::Model& model) {
                 .flag("GENERATE")
         );
 
-        // Store keyword state shared by all data-layout variants
-        command.on_enter([ctx](const dsl::Keys& keys) {
+        // Store keyword state and create the destination even when no data rows follow
+        command.on_enter([&model, ctx](const dsl::ParentInfo& parent, const dsl::Keys& keys) {
             ctx->name     = keys.raw("SFSET");
             ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
+
+            if (parent.command == "ASSEMBLY") {
+                if (!model._data->compiled) return;
+
+                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                    "SFSET: instance ", ctx->instance, " is not defined");
+
+                model._data->surface_sets.activate(ctx->name);
+                return;
+            }
+
+            logging::error(ctx->instance.empty(),
+                "SFSET: INSTANCE is only valid at assembly level");
+            if (model._data->compiled) return;
+
+            const auto part = model._data->parts.get();
+            logging::error(part != nullptr,
+                "SFSET: no active part is available");
+
+            part->surface_sets.activate(ctx->name);
         });
 
         const auto part_scope     = dsl::Condition::parent_is({"ROOT", "PART"});

--- a/src/io/reader/commands/register_sfset.inl
+++ b/src/io/reader/commands/register_sfset.inl
@@ -3,25 +3,18 @@
  * @brief Registers part-local and assembly-level surface sets.
  *
  * `SFSET` accepts explicit surface or surface-set references and generated
- * arithmetic ranges. String references are delegated to
- * `Model::add_surfaces_to_set()` so the same set-composition semantics apply
- * before and after compilation. Part-local definitions retain sparse surface
- * IDs in the active Part, whereas assembly-level references may use optional
- * Instance qualification and are resolved through the compiled local-to-global
- * surface maps.
+ * arithmetic ranges. Part/root variants retain sparse surface identifiers in
+ * the active Part, while assembly variants are replayed after compilation and
+ * resolve optional Instance qualification through compiled surface maps.
  *
- * `GENERATE` remains a numeric path because its arithmetic range already
- * provides surface identifiers directly and does not require string-reference
- * interpretation.
- *
- * The resulting `SurfaceRegion` provides a reusable target for pressure,
- * traction, contact, coupling and tie definitions.
+ * Scope-dependent behavior is selected declaratively through DSL variants. No
+ * separate parser-level assembly flag is required.
  *
  * @see model::Model::add_surfaces_to_set
  * @see model::SurfaceRegion
  *
  * @author Finn Eggers
- * @date 24.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
@@ -36,71 +29,70 @@
 
 namespace fem::io::reader::commands {
 
-inline void register_sfset(fem::io::dsl::Registry& registry,
-                           model::Model& model,
-                           std::shared_ptr<bool> assembly_scope) {
-    registry.command("SFSET", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the `SFSET` command for part-local and compiled assembly scopes.
+ */
+inline void register_sfset(dsl::Registry& registry, model::Model& model) {
+    registry.command("SFSET", [&](dsl::Command& command) {
+        // Allow surface sets in the unqualified root, part and assembly scopes
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
 
         struct Context {
-            bool assembly = false;
             std::string name;
             std::string instance;
-            model::SurfaceRegion::Ptr destination = nullptr;
         };
         auto ctx = std::make_shared<Context>();
 
+        // Define the set name, optional assembly Instance and generated-range mode
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("SFSET").alternative("NAME").optional("SFALL")
                 .key("INSTANCE").optional()
                 .flag("GENERATE")
         );
-        command.on_enter([&model, assembly_scope, ctx](const fem::io::dsl::Keys& keys) {
-            ctx->assembly    = *assembly_scope;
-            ctx->name        = keys.raw("SFSET");
-            ctx->instance    = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
-            ctx->destination = nullptr;
 
-            logging::error(ctx->assembly || ctx->instance.empty(),
-                "SFSET: INSTANCE is only valid at assembly level");
-
-            if (ctx->assembly) {
-                if (!model._data->compiled) return;
-                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
-                    "SFSET: instance ", ctx->instance, " is not defined");
-                ctx->destination = model._data->surface_sets.activate(ctx->name);
-            } else if (!model._data->compiled) {
-                const auto part = model._data->parts.get();
-                logging::error(part != nullptr,
-                    "SFSET: no active part is available");
-                ctx->destination = part->surface_sets.activate(ctx->name);
-            }
+        // Store keyword state shared by all data-layout variants
+        command.on_enter([ctx](const dsl::Keys& keys) {
+            ctx->name     = keys.raw("SFSET");
+            ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
         });
 
-        const std::string missing_token = "__MISSING__";
+        const auto part_scope     = dsl::Condition::parent_is({"ROOT", "PART"});
+        const auto assembly_scope = dsl::Condition::parent_is("ASSEMBLY");
+        const auto generated      = dsl::Condition::key_true("GENERATE");
+        const auto listed         = dsl::Condition::any_of({
+            dsl::Condition::negate(dsl::Condition::key_present("GENERATE")),
+            dsl::Condition::key_false("GENERATE")
+        });
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::key_true("GENERATE"))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(0))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Expand generated ranges directly into sparse part-local surface identifiers
+        command.variant(dsl::Variant::make()
+            .rank(10)
+            .when(dsl::Condition::all_of({part_scope, generated}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
                     .one<ID>().name("START")
                     .one<ID>().name("END")
                     .one<ID>().name("INC").on_missing(ID{1}).on_empty(ID{1})
                 )
                 .bind([&model, ctx](ID first, ID last, ID inc) {
+                    logging::error(ctx->instance.empty(),
+                        "SFSET: INSTANCE is only valid at assembly level");
                     logging::error(inc != 0,
                         "SFSET/GENERATE: increment must not be zero");
-                    if (!ctx->destination) return;
+                    if (model._data->compiled) return;
                     if ((inc > 0 && first > last) || (inc < 0 && first < last)) return;
 
+                    const auto part = model._data->parts.get();
+                    logging::error(part != nullptr,
+                        "SFSET: no active part is available");
+                    const auto destination = part->surface_sets.activate(ctx->name);
+
                     for (ID id = first;; id += inc) {
-                        const ID value = ctx->assembly
-                            ? (ctx->instance.empty() ? model.compiled_surface_id(id)
-                                                     : model.compiled_surface_id(id, ctx->instance))
-                            : id;
-                        ctx->destination->add(value);
+                        destination->add(id);
 
                         const ID next = static_cast<ID>(id + inc);
                         if (inc > 0 ? next > last : next < last) break;
@@ -109,19 +101,79 @@ inline void register_sfset(fem::io::dsl::Registry& registry,
             )
         );
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::any_of({
-                fem::io::dsl::Condition::negate(fem::io::dsl::Condition::key_present("GENERATE")),
-                fem::io::dsl::Condition::key_false("GENERATE")
-            }))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(0))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Expand generated assembly ranges through the compiled Instance mapping
+        command.variant(dsl::Variant::make()
+            .rank(10)
+            .when(dsl::Condition::all_of({assembly_scope, generated}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
+                    .one<ID>().name("START")
+                    .one<ID>().name("END")
+                    .one<ID>().name("INC").on_missing(ID{1}).on_empty(ID{1})
+                )
+                .bind([&model, ctx](ID first, ID last, ID inc) {
+                    logging::error(inc != 0,
+                        "SFSET/GENERATE: increment must not be zero");
+                    if (!model._data->compiled) return;
+                    if ((inc > 0 && first > last) || (inc < 0 && first < last)) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "SFSET: instance ", ctx->instance, " is not defined");
+                    const auto destination = model._data->surface_sets.activate(ctx->name);
+
+                    for (ID id = first;; id += inc) {
+                        const ID value = ctx->instance.empty()
+                            ? model.compiled_surface_id(id)
+                            : model.compiled_surface_id(id, ctx->instance);
+                        destination->add(value);
+
+                        const ID next = static_cast<ID>(id + inc);
+                        if (inc > 0 ? next > last : next < last) break;
+                    }
+                })
+            )
+        );
+
+        const std::string missing_token = "__MISSING__";
+
+        // Resolve listed part-local surface or surface-set references in the active Part
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({part_scope, listed}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
                     .fixed<std::string, 32>().name("TARGET")
                         .on_missing(missing_token).on_empty(missing_token)
                 )
                 .bind([&model, ctx, missing_token](const std::array<std::string, 32>& targets) {
-                    if (!ctx->destination) return;
+                    logging::error(ctx->instance.empty(),
+                        "SFSET: INSTANCE is only valid at assembly level");
+                    if (model._data->compiled) return;
+
+                    for (const std::string& target : targets) {
+                        if (target == missing_token) continue;
+                        model.add_surfaces_to_set(ctx->name, target);
+                    }
+                })
+            )
+        );
+
+        // Resolve listed assembly references with optional Instance qualification
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({assembly_scope, listed}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(0))
+                .pattern(dsl::Pattern::make()
+                    .fixed<std::string, 32>().name("TARGET")
+                        .on_missing(missing_token).on_empty(missing_token)
+                )
+                .bind([&model, ctx, missing_token](const std::array<std::string, 32>& targets) {
+                    if (!model._data->compiled) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "SFSET: instance ", ctx->instance, " is not defined");
+
                     for (const std::string& target : targets) {
                         if (target == missing_token) continue;
                         model.add_surfaces_to_set(ctx->name, target, ctx->instance);

--- a/src/io/reader/commands/register_surface.inl
+++ b/src/io/reader/commands/register_surface.inl
@@ -4,32 +4,20 @@
  *
  * The command provides the shared `SURFACE` grammar used by FEMaster and Abaqus
  * input decks. Element-based rows associate an element or element set with one
- * of its boundary sides, construct the corresponding element-specific surface
- * or line representation and register the resulting identifiers under the
- * requested surface name.
+ * of its boundary sides and construct the corresponding surface or line region.
+ * Node-based rows populate a named `NodeRegion`.
  *
- * Before compilation, element-based definitions remain part-local and retain
- * sparse semantic identifiers. Assembly-level definitions are replayed after
- * compilation so Instance-qualified references can be resolved through the
- * dense local-to-global maps without duplicating geometric topology.
- *
- * `TYPE=NODE` represents a node-based surface as a named `NodeRegion`. Its data
- * rows may reference individual nodes or existing node sets and therefore share
- * the same Model-level set population path used by `NSET` definitions before
- * and after compilation. The optional Abaqus nodal-area value is parsed for
- * syntax compatibility but is currently not stored because `NodeRegion` carries
- * identifiers rather than per-node weighting data.
- *
- * The shared keyword grammar accepts FEMaster `SFSET` and Abaqus `NAME` naming,
- * preserves the FEMaster explicit surface-ID row form, and supports optional
- * assembly `INSTANCE` qualification for both input formats.
+ * Part/root and assembly semantics are represented by separate DSL variants.
+ * Part-local definitions retain sparse semantic identifiers before compilation,
+ * while assembly variants are replayed afterwards and resolve optional Instance
+ * qualification through the compiled local-to-global maps.
  *
  * @see model::NodeRegion
  * @see model::SurfaceRegion
  * @see model::LineRegion
  *
  * @author Finn Eggers
- * @date 24.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
@@ -47,62 +35,44 @@
 
 namespace fem::io::reader::commands {
 
-inline void register_surface(fem::io::dsl::Registry& registry,
-                             model::Model& model,
-                             std::shared_ptr<bool> assembly_scope) {
-    registry.command("SURFACE", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers node- and element-based `SURFACE` definitions.
+ */
+inline void register_surface(dsl::Registry& registry, model::Model& model) {
+    registry.command("SURFACE", [&](dsl::Command& command) {
+        // Allow surfaces in the unqualified root, part and assembly scopes
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
 
         struct Context {
-            bool assembly = false;
             std::string name;
             std::string type;
             std::string instance;
-            model::NodeRegion::Ptr node_destination = nullptr;
         };
         auto ctx = std::make_shared<Context>();
 
+        // Define naming, surface representation and optional assembly qualification
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("SFSET").alternative("NAME").optional("SFALL")
                 .key("TYPE").optional("ELEMENT").allowed({"ELEMENT", "NODE"})
                 .key("INSTANCE").optional()
         );
-        command.on_enter([&model, assembly_scope, ctx](const fem::io::dsl::Keys& keys) {
-            ctx->assembly         = *assembly_scope;
-            ctx->name             = keys.raw("SFSET");
-            ctx->type             = keys.raw("TYPE");
-            ctx->instance         = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
-            ctx->node_destination = nullptr;
 
-            logging::error(ctx->assembly || ctx->instance.empty(),
-                "SURFACE: INSTANCE is only valid at assembly level");
-
-            if (ctx->assembly) {
-                if (!model._data->compiled) return;
-                logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
-                    "SURFACE: instance ", ctx->instance, " is not defined");
-                if (ctx->type == "NODE") {
-                    ctx->node_destination = model._data->node_sets.activate(ctx->name);
-                } else {
-                    model._data->surface_sets.activate(ctx->name)->sorted(true).duplicates(false);
-                    model._data->line_sets.activate(ctx->name)->sorted(true).duplicates(false);
-                }
-                return;
-            }
-
-            if (model._data->compiled) return;
-            const auto part = model._data->parts.get();
-            logging::error(part != nullptr,
-                "SURFACE: no active part is available");
-            if (ctx->type == "NODE") {
-                ctx->node_destination = part->node_sets.activate(ctx->name);
-            } else {
-                part->surface_sets.activate(ctx->name)->sorted(true).duplicates(false);
-                part->line_sets.activate(ctx->name)->sorted(true).duplicates(false);
-            }
+        // Store keyword state shared by all surface-layout variants
+        command.on_enter([ctx](const dsl::Keys& keys) {
+            ctx->name     = keys.raw("SFSET");
+            ctx->type     = keys.raw("TYPE");
+            ctx->instance = keys.has("INSTANCE") ? keys.raw("INSTANCE") : std::string{};
         });
 
+        const auto part_scope      = dsl::Condition::parent_is({"ROOT", "PART"});
+        const auto assembly_scope  = dsl::Condition::parent_is("ASSEMBLY");
+        const auto element_surface = dsl::Condition::key_equals("TYPE", {"ELEMENT"});
+        const auto node_surface    = dsl::Condition::key_equals("TYPE", {"NODE"});
+
+        // Translate Abaqus/FEMaster side labels into the element boundary index
         auto parse_side = [](const std::string& side_token) -> int {
             if (side_token.empty()) return 1;
 
@@ -118,11 +88,14 @@ inline void register_surface(fem::io::dsl::Registry& registry,
             const char* begin = numeric.data();
             const char* end   = begin + numeric.size();
             const auto [ptr, ec] = std::from_chars(begin, end, side);
+
             logging::error(ec == std::errc{} && ptr == end,
                 "SURFACE: side ", side_token, " is not a valid face identifier");
+
             return side;
         };
 
+        // Materialize one compiled element boundary as a surface or line entity
         auto add_compiled_boundary = [&model](ID element_id, ID side, const std::string& name) {
             logging::error(element_id >= 0 && static_cast<std::size_t>(element_id) < model._data->elements.size(),
                 "SURFACE: compiled element ", element_id, " is out of range");
@@ -132,6 +105,7 @@ inline void register_surface(fem::io::dsl::Registry& registry,
             const auto element = model._data->elements[static_cast<std::size_t>(element_id)];
             auto surface = element->surface(side);
             auto line    = element->line(side);
+
             logging::error(surface != nullptr || line != nullptr,
                 "SURFACE: boundary ", side, " of compiled element ", element_id,
                 " provides neither a surface nor a line");
@@ -148,59 +122,56 @@ inline void register_surface(fem::io::dsl::Registry& registry,
             }
         };
 
-        command.variant(fem::io::dsl::Variant::make()
+        // Preserve the FEMaster explicit surface-id form for part-local definitions
+        command.variant(dsl::Variant::make()
             .rank(20)
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {"ELEMENT"}))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
+            .when(dsl::Condition::all_of({part_scope, element_surface}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
                     .one<ID>().name("ID")
                     .one<ID>().name("ELEM_ID")
                     .one<std::string>().name("SIDE")
                 )
                 .bind([&model, ctx, parse_side](ID id, ID element_id, const std::string& side_token) {
-                    logging::error(!ctx->assembly,
-                        "SURFACE: explicit surface ids are not supported at assembly level");
-                    if (!model._data->compiled) {
-                        model.set_surface(id, element_id, parse_side(side_token));
-                    }
+                    logging::error(ctx->instance.empty(),
+                        "SURFACE: INSTANCE is only valid at assembly level");
+                    if (model._data->compiled) return;
+
+                    const auto part = model._data->parts.get();
+                    logging::error(part != nullptr,
+                        "SURFACE: no active part is available");
+                    part->surface_sets.activate(ctx->name)->sorted(true).duplicates(false);
+                    part->line_sets.activate(ctx->name)->sorted(true).duplicates(false);
+
+                    model.set_surface(id, element_id, parse_side(side_token));
                 })
             )
         );
 
-        command.variant(fem::io::dsl::Variant::make()
+        // Resolve part-local element or element-set references against sparse topology
+        command.variant(dsl::Variant::make()
             .rank(10)
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {"ELEMENT"}))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
+            .when(dsl::Condition::all_of({part_scope, element_surface}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
                     .one<std::string>().name("TARGET")
                     .one<std::string>().name("SIDE")
                 )
-                .bind([&model, ctx, parse_side, add_compiled_boundary](const std::string& target,
-                                                                       const std::string& side_token) {
-                    const ID side = static_cast<ID>(parse_side(side_token));
-                    if (ctx->assembly) {
-                        if (!model._data->compiled) return;
-
-                        const std::string reference = io::reader::qualify_reference(target, ctx->instance);
-                        if (model._data->elem_sets.has(reference)) {
-                            const auto elements = model._data->elem_sets.get(reference);
-                            logging::error(elements != nullptr,
-                                "SURFACE: element set ", reference, " is not initialized");
-                            for (const ID element_id : *elements) {
-                                add_compiled_boundary(element_id, side, ctx->name);
-                            }
-                        } else {
-                            add_compiled_boundary(io::reader::compiled_element_id(model, reference), side, ctx->name);
-                        }
-                        return;
-                    }
-
+                .bind([&model, ctx, parse_side](const std::string& target, const std::string& side_token) {
+                    logging::error(ctx->instance.empty(),
+                        "SURFACE: INSTANCE is only valid at assembly level");
                     if (model._data->compiled) return;
+
+                    const ID side = static_cast<ID>(parse_side(side_token));
                     const auto part = model._data->parts.get();
                     logging::error(part != nullptr,
                         "SURFACE: no active part is available");
+
+                    part->surface_sets.activate(ctx->name)->sorted(true).duplicates(false);
+                    part->line_sets.activate(ctx->name)->sorted(true).duplicates(false);
+
                     if (part->elem_sets.has(target)) {
                         model.set_surface(target, side);
                     } else {
@@ -210,17 +181,77 @@ inline void register_surface(fem::io::dsl::Registry& registry,
             )
         );
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {"NODE"}))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Resolve assembly element references and materialize their compiled boundaries
+        command.variant(dsl::Variant::make()
+            .rank(10)
+            .when(dsl::Condition::all_of({assembly_scope, element_surface}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
+                    .one<std::string>().name("TARGET")
+                    .one<std::string>().name("SIDE")
+                )
+                .bind([&model, ctx, parse_side, add_compiled_boundary](const std::string& target,
+                                                                       const std::string& side_token) {
+                    if (!model._data->compiled) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "SURFACE: instance ", ctx->instance, " is not defined");
+
+                    const ID side = static_cast<ID>(parse_side(side_token));
+                    const std::string reference = io::reader::qualify_reference(target, ctx->instance);
+
+                    if (model._data->elem_sets.has(reference)) {
+                        const auto elements = model._data->elem_sets.get(reference);
+                        logging::error(elements != nullptr,
+                            "SURFACE: element set ", reference, " is not initialized");
+
+                        for (const ID element_id : *elements) {
+                            add_compiled_boundary(element_id, side, ctx->name);
+                        }
+                    } else {
+                        add_compiled_boundary(io::reader::compiled_element_id(model, reference), side, ctx->name);
+                    }
+                })
+            )
+        );
+
+        // Populate a part-local node-based surface through sparse node references
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({part_scope, node_surface}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
                     .one<std::string>().name("TARGET")
                     .one<Precision>().name("AREA").on_missing(Precision{1}).on_empty(Precision{1})
                 )
                 .bind([&model, ctx](const std::string& target, Precision area) {
                     (void) area;
-                    if (!ctx->node_destination) return;
+                    logging::error(ctx->instance.empty(),
+                        "SURFACE: INSTANCE is only valid at assembly level");
+                    if (model._data->compiled) return;
+
+                    model.add_nodes_to_set(ctx->name, target);
+                })
+            )
+        );
+
+        // Populate an assembly node-based surface through compiled node references
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::all_of({assembly_scope, node_surface}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
+                    .one<std::string>().name("TARGET")
+                    .one<Precision>().name("AREA").on_missing(Precision{1}).on_empty(Precision{1})
+                )
+                .bind([&model, ctx](const std::string& target, Precision area) {
+                    (void) area;
+                    if (!model._data->compiled) return;
+
+                    logging::error(ctx->instance.empty() || model._data->instances.has(ctx->instance),
+                        "SURFACE: instance ", ctx->instance, " is not defined");
+
                     model.add_nodes_to_set(ctx->name, target, ctx->instance);
                 })
             )

--- a/src/io/reader/commands_abq/register_assembly.inl
+++ b/src/io/reader/commands_abq/register_assembly.inl
@@ -2,40 +2,39 @@
  * @file register_assembly.inl
  * @brief Registers the Abaqus ASSEMBLY scope.
  *
- * FEMaster has one model-level assembly, so the Abaqus `ASSEMBLY` keyword opens
- * a syntactic and parser-local scope rather than allocating a second domain
- * object. The shared flag tells set, surface, Instance and transformation
- * commands when references must be interpreted at assembly level.
- *
- * Scope state is local to each parser pass and is cleared by `END ASSEMBLY`,
- * preserving correct nesting while inactive callbacks are consume-only.
+ * FEMaster has one model-level assembly, so the Abaqus `ASSEMBLY` keyword only
+ * opens the corresponding grammar scope. Parent-dependent set and surface
+ * behavior is selected directly through DSL variant conditions.
  *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
-
-#include <memory>
 
 #include "../../dsl/condition.h"
 #include "../../dsl/keyword.h"
 
 namespace fem::io::reader::commands_abq {
 
-inline void register_assembly(fem::io::dsl::Registry& registry,
-                              std::shared_ptr<bool> assembly_scope) {
-    registry.command("ASSEMBLY", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("ROOT"));
-        command.doc("Begin the Abaqus assembly scope.");
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the root-level Abaqus `ASSEMBLY` grammar scope.
+ */
+inline void register_assembly(dsl::Registry& registry) {
+    registry.command("ASSEMBLY", [&](dsl::Command& command) {
+        // Restrict ASSEMBLY to the root scope
+        command.allow_if(dsl::Condition::parent_is("ROOT"));
+
+        // Define the optional Abaqus assembly name
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("NAME").optional("ASSEMBLY").doc("Assembly name")
         );
-        command.on_enter([assembly_scope](const fem::io::dsl::Keys&) {
-            *assembly_scope = true;
-        });
-        command.variant(fem::io::dsl::Variant::make());
+
+        // ASSEMBLY only introduces a grammar scope
+        command.variant(dsl::Variant::make());
     });
 }
 

--- a/src/io/reader/commands_abq/register_element.inl
+++ b/src/io/reader/commands_abq/register_element.inl
@@ -18,13 +18,12 @@
  * `Model::compile()`.
  *
  * @author Finn Eggers
- * @date 24.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
 
 #include <array>
-#include <memory>
 #include <utility>
 
 #include "../../../model/beam/b33.h"
@@ -48,6 +47,8 @@
 
 namespace fem::io::reader::commands_abq {
 
+namespace dsl = fem::io::dsl;
+
 template<class Elem, std::size_t N, std::size_t... I>
 inline void set_abq_element_impl(model::Model& model,
                                  ID id,
@@ -61,35 +62,42 @@ inline void set_abq_element(model::Model& model, ID id, const std::array<ID, N>&
     set_abq_element_impl<Elem, N>(model, id, nodes, std::make_index_sequence<N>{});
 }
 
-inline void register_element(fem::io::dsl::Registry& registry,
-                             model::Model& model,
-                             std::shared_ptr<bool> assembly_scope) {
-    registry.command("ELEMENT", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+/**
+ * @brief Registers Abaqus element connectivity before model compilation.
+ */
+inline void register_element(dsl::Registry& registry, model::Model& model) {
+    registry.command("ELEMENT", [&](dsl::Command& command) {
+        // Abaqus elements may be defined directly, in a Part or in the assembly scope
+        command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
+
+        // Define the destination set and supported Abaqus element labels
         command.keyword(
-            fem::io::dsl::KeywordSpec::make()
+            dsl::KeywordSpec::make()
                 .key("ELSET").optional("EALL")
                 .key("TYPE").required().allowed({
                     "C3D4", "C3D5", "C3D6", "C3D8", "C3D8R", "C3D10", "C3D15", "C3D20", "C3D20R",
                     "B33", "T3D2", "S3", "S3R", "S4", "S4R", "S6", "S6R", "S8", "S8R", "MASS"
                 })
         );
-        command.on_enter([&model, assembly_scope](const fem::io::dsl::Keys& keys) {
+
+        // Prepare the active element set before processing connectivity rows
+        command.on_enter([&model](const dsl::Keys& keys) {
             logging::error(model._data != nullptr && !model._data->compiled,
                 "ELEMENT: elements cannot be added after compile()");
-            if (*assembly_scope) model._data->parts.activate(model::Model::DEFAULT_PART_NAME);
+
             const auto part = model._data->parts.get();
             logging::error(part != nullptr,
                 "ELEMENT: no active part is available");
+
             part->elem_sets.activate(keys.raw("ELSET"));
         });
 
 #define FEM_ABQ_ELEMENT(KEY, ELEM, COUNT) \
-        command.variant(fem::io::dsl::Variant::make() \
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {KEY})) \
-            .segment(fem::io::dsl::Segment::make() \
-                .range(fem::io::dsl::LineRange{}.min(1)) \
-                .pattern(fem::io::dsl::Pattern::make() \
+        command.variant(dsl::Variant::make() \
+            .when(dsl::Condition::key_equals("TYPE", {KEY})) \
+            .segment(dsl::Segment::make() \
+                .range(dsl::LineRange{}.min(1)) \
+                .pattern(dsl::Pattern::make() \
                     .allow_multiline() \
                     .one<ID>().name("ID") \
                     .fixed<ID, COUNT>().name("N") \
@@ -100,6 +108,7 @@ inline void register_element(fem::io::dsl::Registry& registry,
             ) \
         );
 
+        // Register direct Abaqus-to-FEMaster topology mappings
         FEM_ABQ_ELEMENT("C3D4", C3D4, 4);
         FEM_ABQ_ELEMENT("C3D6", C3D6, 6);
         FEM_ABQ_ELEMENT("C3D8", C3D8, 8);
@@ -122,11 +131,12 @@ inline void register_element(fem::io::dsl::Registry& registry,
 
 #undef FEM_ABQ_ELEMENT
 
-        command.variant(fem::io::dsl::Variant::make()
-            .when(fem::io::dsl::Condition::key_equals("TYPE", {"C3D5"}))
-            .segment(fem::io::dsl::Segment::make()
-                .range(fem::io::dsl::LineRange{}.min(1))
-                .pattern(fem::io::dsl::Pattern::make()
+        // Expand Abaqus C3D5 into the supported degenerate C3D8 topology
+        command.variant(dsl::Variant::make()
+            .when(dsl::Condition::key_equals("TYPE", {"C3D5"}))
+            .segment(dsl::Segment::make()
+                .range(dsl::LineRange{}.min(1))
+                .pattern(dsl::Pattern::make()
                     .allow_multiline()
                     .one<ID>().name("ID")
                     .fixed<ID, 5>().name("N")

--- a/src/io/reader/commands_abq/register_end_assembly.inl
+++ b/src/io/reader/commands_abq/register_end_assembly.inl
@@ -2,36 +2,33 @@
  * @file register_end_assembly.inl
  * @brief Registers the Abaqus ENDASSEMBLY scope terminator.
  *
- * `END ASSEMBLY` closes the syntactic assembly scope and clears the shared
- * parser-local flag used to interpret qualified sets, surfaces and Instances.
- * FEMaster's model-level assembly remains alive because the keyword controls
- * parsing context rather than object lifetime.
- *
- * Registering the terminator in every pass preserves Abaqus nesting even when
- * its callback is inactive and the deck is only being consumed.
+ * `ENDASSEMBLY` closes the Abaqus assembly grammar scope. FEMaster's model-level
+ * assembly remains alive because the keyword controls parsing context rather
+ * than object lifetime.
  *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 25.08.2026
  */
 
 #pragma once
-
-#include <memory>
 
 #include "../../dsl/condition.h"
 #include "../../dsl/keyword.h"
 
 namespace fem::io::reader::commands_abq {
 
-inline void register_end_assembly(fem::io::dsl::Registry& registry,
-                                  std::shared_ptr<bool> assembly_scope) {
-    registry.command("ENDASSEMBLY", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("ASSEMBLY"));
-        command.doc("Terminate the Abaqus assembly scope.");
-        command.on_enter([assembly_scope](const fem::io::dsl::Keys&) {
-            *assembly_scope = false;
-        });
-        command.variant(fem::io::dsl::Variant::make());
+namespace dsl = fem::io::dsl;
+
+/**
+ * @brief Registers the Abaqus `ENDASSEMBLY` grammar-scope terminator.
+ */
+inline void register_end_assembly(dsl::Registry& registry) {
+    registry.command("ENDASSEMBLY", [&](dsl::Command& command) {
+        // ENDASSEMBLY is only valid for an active assembly scope
+        command.allow_if(dsl::Condition::parent_is("ASSEMBLY"));
+
+        // The command only closes the grammar scope
+        command.variant(dsl::Variant::make());
     });
 }
 

--- a/src/io/reader/commands_abq/register_end_assembly.inl
+++ b/src/io/reader/commands_abq/register_end_assembly.inl
@@ -26,6 +26,7 @@ inline void register_end_assembly(dsl::Registry& registry) {
     registry.command("ENDASSEMBLY", [&](dsl::Command& command) {
         // ENDASSEMBLY is only valid for an active assembly scope
         command.allow_if(dsl::Condition::parent_is("ASSEMBLY"));
+        command.closes_parent();
 
         // The command only closes the grammar scope
         command.variant(dsl::Variant::make());

--- a/src/io/reader/commands_abq/register_end_instance.inl
+++ b/src/io/reader/commands_abq/register_end_instance.inl
@@ -23,6 +23,7 @@ namespace fem::io::reader::commands_abq {
 inline void register_end_instance(fem::io::dsl::Registry& registry) {
     registry.command("ENDINSTANCE", [&](fem::io::dsl::Command& command) {
         command.allow_if(fem::io::dsl::Condition::parent_is("INSTANCE"));
+        command.closes_parent();
         command.doc("Terminate the current Abaqus instance scope.");
         command.variant(fem::io::dsl::Variant::make());
     });

--- a/src/io/reader/commands_abq/register_step.inl
+++ b/src/io/reader/commands_abq/register_step.inl
@@ -498,6 +498,7 @@ inline void register_step(fem::io::dsl::Registry& registry, ParserAbq& parser) {
     // ---------------------------------------------------------------------
     registry.command("ENDSTEP", [&](fem::io::dsl::Command& command) {
         command.allow_if(fem::io::dsl::Condition::parent_is("STEP"));
+        command.closes_parent();
         command.doc("Execute and finish the active Abaqus analysis step.");
 
         command.on_enter([&parser](const fem::io::dsl::Keys&) {

--- a/src/io/reader/parser.cpp
+++ b/src/io/reader/parser.cpp
@@ -367,8 +367,9 @@ void Parser::run_analysis_pass(const std::string& input_path,
 /**
  * Configures the pass that collects shared model definitions.
  *
- * A fresh registry recognizes the entire FEMaster grammar but activates only
- * shared definitions required by later topology and section commands.
+ * The complete grammar remains available for nesting and validation, but only
+ * material laws, profiles and coordinate orientations execute callbacks. These
+ * definitions may therefore be referenced later regardless of deck order.
  *
  * @param registry Empty pass-local registry to configure.
  */
@@ -391,8 +392,9 @@ void Parser::configure_definition_pass(io::dsl::Registry& registry) {
 /**
  * Configures construction of sparse semantic topology before compilation.
  *
- * Parts, Instances, local topology and part-level section assignments execute while
- * global assembly fields and analyses are consumed without mutating state.
+ * Part and Instance scopes, local entities, regions and part-level section
+ * assignments execute while global assembly fields and analyses are consumed
+ * without mutating state.
  *
  * @param registry Empty pass-local registry to configure.
  */

--- a/src/io/reader/parser.cpp
+++ b/src/io/reader/parser.cpp
@@ -148,7 +148,7 @@ void Parser::run(const std::string& input_path,
     // Cross the one-way boundary into deterministic dense assembly storage
     model_->compile();
 
-    // Materialize post-compile regions, fields and shell reference normals
+    // Materialize post-compile assembly regions, fields and shell normals
     run_assembly_pass(input_path);
 
     // Execute loads, constraints and load cases against the completed assembly
@@ -482,8 +482,8 @@ void Parser::configure_documentation_registry() {
  *
  * Every parsing pass uses the same grammar. Active modes control whether a
  * command executes its callback or is only consumed to preserve the original
- * scope hierarchy. The assembly-scope flag is shared by topology callbacks
- * belonging to this registry and therefore resets naturally for every replay.
+ * scope hierarchy. Parent-dependent behavior is represented directly by DSL
+ * conditions and variants rather than duplicated parser-local scope flags.
  *
  * Model-oriented commands receive the current Model directly. Load-case commands
  * receive the Parser because they coordinate consecutive commands through the
@@ -492,26 +492,25 @@ void Parser::configure_documentation_registry() {
  * @param registry Registry that receives the complete command definitions.
  */
 void Parser::register_commands(io::dsl::Registry& registry) {
-    // Validate the callback target and initialize registry-local assembly scope
+    // Validate the callback target before registering model-oriented commands
     logging::error(model_ != nullptr,
         "Parser: model must exist before registering commands");
 
     auto& mdl = *model_;
-    auto assembly_scope = std::make_shared<bool>(false);
 
-    // Register semantic Part/Instance topology and assembly-scope commands
+    // Register semantic Part/Instance topology and scope-aware assembly commands
     commands::register_part        (registry, mdl);
     commands::register_end_part    (registry, mdl);
-    commands::register_assembly    (registry, assembly_scope);
-    commands::register_end_assembly(registry, assembly_scope);
+    commands::register_assembly    (registry);
+    commands::register_end_assembly(registry);
     commands_abq::register_instance(registry, mdl);
     commands::register_end_instance(registry);
-    commands::register_node        (registry, mdl, assembly_scope);
-    commands::register_element     (registry, mdl, assembly_scope);
-    commands::register_nset        (registry, mdl, assembly_scope);
-    commands::register_elset       (registry, mdl, assembly_scope);
-    commands::register_surface     (registry, mdl, assembly_scope);
-    commands::register_sfset       (registry, mdl, assembly_scope);
+    commands::register_node        (registry, mdl);
+    commands::register_element     (registry, mdl);
+    commands::register_nset        (registry, mdl);
+    commands::register_elset       (registry, mdl);
+    commands::register_surface     (registry, mdl);
+    commands::register_sfset       (registry, mdl);
 
     // Register the root model and load-case terminator scopes
     registry.command("MODEL", [](io::dsl::Command& command) {

--- a/src/io/reader/parser.cpp
+++ b/src/io/reader/parser.cpp
@@ -367,9 +367,8 @@ void Parser::run_analysis_pass(const std::string& input_path,
 /**
  * Configures the pass that collects shared model definitions.
  *
- * The complete grammar remains available for nesting and validation, but only
- * material laws, profiles and coordinate orientations execute callbacks. These
- * definitions may therefore be referenced later regardless of deck order.
+ * A fresh registry recognizes the entire FEMaster grammar but activates only
+ * shared definitions required by later topology and section commands.
  *
  * @param registry Empty pass-local registry to configure.
  */
@@ -392,9 +391,8 @@ void Parser::configure_definition_pass(io::dsl::Registry& registry) {
 /**
  * Configures construction of sparse semantic topology before compilation.
  *
- * Part and Instance scopes, local entities, regions and part-level section
- * assignments execute while global assembly fields and analyses are consumed
- * without mutating state.
+ * Parts, Instances, local topology and part-level section assignments execute while
+ * global assembly fields and analyses are consumed without mutating state.
  *
  * @param registry Empty pass-local registry to configure.
  */
@@ -520,6 +518,7 @@ void Parser::register_commands(io::dsl::Registry& registry) {
     });
     registry.command("END", [](io::dsl::Command& command) {
         command.allow_if(io::dsl::Condition::parent_is("LOADCASE"));
+        command.closes_parent();
         command.variant(io::dsl::Variant::make());
     });
 

--- a/src/io/reader/parser_abq.cpp
+++ b/src/io/reader/parser_abq.cpp
@@ -100,21 +100,19 @@ std::pair<Precision, std::string> ParserAbq::resolve_load_amplitude(const std::s
     return {Precision(1), std::string{}};
 }
 
-void ParserAbq::register_common_commands(io::dsl::Registry& registry,
-                                         std::shared_ptr<bool> assembly_scope) {
+void ParserAbq::register_common_commands(io::dsl::Registry& registry) {
     // Register the complete Abaqus subset once per parser pass. ActiveMode below
-    // controls execution; keeping one common grammar preserves scope handling
-    // even when a command is only consumed in the current pass.
+    // controls execution while the DSL scope stack provides all parent context.
     commands::register_heading(registry);
     commands::register_part(registry, model());
     commands::register_end_part(registry, model());
-    commands_abq::register_assembly(registry, assembly_scope);
-    commands_abq::register_end_assembly(registry, assembly_scope);
+    commands_abq::register_assembly(registry);
+    commands_abq::register_end_assembly(registry);
     commands_abq::register_instance(registry, model());
     commands_abq::register_end_instance(registry);
-    commands::register_nset(registry, model(), assembly_scope);
-    commands::register_elset(registry, model(), assembly_scope);
-    commands::register_surface(registry, model(), assembly_scope);
+    commands::register_nset(registry, model());
+    commands::register_elset(registry, model());
+    commands::register_surface(registry, model());
     commands::register_material(registry, model());
     commands::register_density(registry, model());
     commands::register_elastic(registry, model());
@@ -137,10 +135,9 @@ void ParserAbq::register_common_commands(io::dsl::Registry& registry,
 void ParserAbq::configure_definition_pass(io::dsl::Registry& registry) {
     // Definitions may be referenced by part sections during the topology pass.
     // They therefore execute before any part or instance construction.
-    auto assembly_scope = std::make_shared<bool>(false);
-    commands::register_node(registry, model(), assembly_scope);
-    commands_abq::register_element(registry, model(), assembly_scope);
-    register_common_commands(registry, assembly_scope);
+    commands::register_node(registry, model());
+    commands_abq::register_element(registry, model());
+    register_common_commands(registry);
 
     registry.set_active_mode(io::dsl::ActiveMode::ConsumeOnly);
     for (const char* command : {
@@ -151,14 +148,12 @@ void ParserAbq::configure_definition_pass(io::dsl::Registry& registry) {
 }
 
 void ParserAbq::configure_topology_pass(io::dsl::Registry& registry) {
-    // Build semantic parts, instances and part-local section assignments. MASS
-    // variants select ROOT/PART scope declaratively and assembly records are only
-    // consumed until the compiled assembly pass.
+    // Build semantic parts, instances and part-local section assignments. Scope
+    // variants defer assembly records until the compiled assembly pass.
     m_abq_state = ParserAbqState{};
-    auto assembly_scope = std::make_shared<bool>(false);
-    commands::register_node(registry, model(), assembly_scope);
-    commands_abq::register_element(registry, model(), assembly_scope);
-    register_common_commands(registry, assembly_scope);
+    commands::register_node(registry, model());
+    commands_abq::register_element(registry, model());
+    register_common_commands(registry);
 
     registry.set_active_mode(io::dsl::ActiveMode::ConsumeOnly);
     for (const char* command : {
@@ -173,10 +168,9 @@ void ParserAbq::configure_assembly_pass(io::dsl::Registry& registry) {
     // Part-local sections were already expanded by Model::compile(). This pass
     // materializes assembly-local regions, MASS sections and nodal transforms
     // directly in dense identifier space.
-    auto assembly_scope = std::make_shared<bool>(false);
-    commands::register_node(registry, model(), assembly_scope);
-    commands_abq::register_element(registry, model(), assembly_scope);
-    register_common_commands(registry, assembly_scope);
+    commands::register_node(registry, model());
+    commands_abq::register_element(registry, model());
+    register_common_commands(registry);
 
     registry.set_active_mode(io::dsl::ActiveMode::ConsumeOnly);
     for (const char* command : {
@@ -189,10 +183,9 @@ void ParserAbq::configure_assembly_pass(io::dsl::Registry& registry) {
 void ParserAbq::configure_analysis_pass(io::dsl::Registry& registry) {
     // Analysis procedures and boundary/load data consume the final compiled
     // assembly, including all post-compile sets and nodal transforms.
-    auto assembly_scope = std::make_shared<bool>(false);
-    commands::register_node(registry, model(), assembly_scope);
-    commands_abq::register_element(registry, model(), assembly_scope);
-    register_common_commands(registry, assembly_scope);
+    commands::register_node(registry, model());
+    commands_abq::register_element(registry, model());
+    register_common_commands(registry);
 
     registry.set_active_mode(io::dsl::ActiveMode::ConsumeOnly);
     for (const char* command : {

--- a/src/io/reader/parser_abq.h
+++ b/src/io/reader/parser_abq.h
@@ -26,7 +26,6 @@
 
 #include "parser.h"
 
-#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -65,8 +64,7 @@ protected:
     void configure_analysis_pass  (io::dsl::Registry& registry) override;
 
 private:
-    void register_common_commands(io::dsl::Registry& registry,
-                                  std::shared_ptr<bool> assembly_scope);
+    void register_common_commands(io::dsl::Registry& registry);
 };
 
 } // namespace fem::io::reader


### PR DESCRIPTION
## Summary

- split `NSET`, `ELSET`, `SFSET` and `SURFACE` behavior by `ROOT`/`PART` vs. `ASSEMBLY` parent scope using ordinary DSL variants
- pass the selected `ParentInfo` into `Command::on_enter(...)` while preserving the existing key-only overload
- create `NSET`, `ELSET` and `SFSET` destinations during command entry so explicitly empty sets remain valid
- restore `DEFAULT_PART_NAME` in `PART::on_exit(...)`, so explicit and implicit scope exits share the same model-state transition
- add `Command::closes_parent()` for explicit scope terminators; after normal processing the admitted parent is popped and its `on_exit` hook fires, while the terminator itself is not pushed as a scope
- use `closes_parent()` for `ENDPART`, FEMaster/Abaqus `ENDASSEMBLY`, FEMaster/Abaqus `ENDINSTANCE`, Abaqus `ENDSTEP`, and FEMaster `END`
- retain the original `parent_is(...)` admission checks, so stray terminators remain invalid
- remove the parser-local `std::shared_ptr<bool>` assembly-scope plumbing from FEMaster and Abaqus readers
- simplify `NODE` / `ELEMENT` registration signatures so they no longer receive assembly parser state

The DSL scope stack is now the single source of truth for parent-dependent behavior. Scope-owned model state is restored by the corresponding scope exit hook, while explicit terminators close that scope through the DSL engine itself.

## Verification

Statically checked against the current parser, DSL and Model interfaces. No build or tests were run, following the project guideline for unrequested validation.