### PR TITLE
Improve null-space constraint conditioning

### DIFF
--- a/src/constraints/transformer/null_space.cpp
+++ b/src/constraints/transformer/null_space.cpp
@@ -156,6 +156,21 @@ build_null_space(const ConstraintSystem& system, const NullSpaceOptions& options
             }
         }
 
+        // Place sparsely participating DOFs first so the basic null-space
+        // partition preferentially eliminates local slave variables instead of
+        // strongly connected interpolation masters. Keeping the global DOF as
+        // a deterministic tie breaker makes the resulting map independent of
+        // sparse insertion order.
+        std::stable_sort(
+            preprocessed.used_columns.begin(),
+            preprocessed.used_columns.end(),
+            [&](int lhs, int rhs) {
+                const Index lhs_count = preprocessed.C.col(lhs).nonZeros();
+                const Index rhs_count = preprocessed.C.col(rhs).nonZeros();
+                return lhs_count != rhs_count ? lhs_count < rhs_count : lhs < rhs;
+            }
+        );
+
         TripletList compact_entries{};
         compact_entries.reserve(preprocessed.C.nonZeros());
         for (int local_column = 0;
@@ -218,7 +233,7 @@ build_null_space(const ConstraintSystem& system, const NullSpaceOptions& options
     }
 
     // Factorize unresolved constraints with column pivoting
-    Eigen::SparseQR<SparseMatrix, Eigen::COLAMDOrdering<int>> qr{};
+    Eigen::SparseQR<SparseMatrix, Eigen::NaturalOrdering<int>> qr{};
     SparseMatrix R{};
     qr_time = Timer::measure_time([&]() {
         const Precision pivot_tolerance = std::min<Precision>(


### PR DESCRIPTION
## Summary

- order unresolved constraint DOFs by sparse participation before QR factorization
- preserve that structural order with Eigen's natural ordering
- avoid selecting strongly connected interpolation masters as dependent DOFs in the basic null-space basis

## Motivation

`solid_rim_m2` produced a poorly conditioned reduced system with the previous COLAMD-based partition. The direct-solver residual was approximately `1.02e-4`, while the same model solved with elimination reached approximately `2.04e-9`.

With this change, the null-space formulation reaches `2.40e-9` without changing Pardiso or adding meaningful transformer runtime.

## Verification

- Release build: `cmake --build build/linux-mkl-omp --parallel 6`
- `solid_rim_m2`: residual `2.3993e-9`; all constraint post-checks pass
- `solid_rim_m1` temporarily run with NULLSPACE: residual `2.11358e-9`; all post-checks pass
- `solid_rim_m3`: residual `3.82936e-9`; all post-checks pass
- `solid_bracket`: residual `2.3782e-10`; all post-checks pass
- `sym_hypel_rubber`: residual `7.9558e-16`; all post-checks pass
- generated results remain within the benchmark reference tolerances