### PR TITLE
Add steady-state thermal analysis

### DIFF
--- a/src/bc/dirichlet/dirichlet.h
+++ b/src/bc/dirichlet/dirichlet.h
@@ -1,0 +1,29 @@
+/**
+ * @file dirichlet.h
+ * @brief Declares the common base for essential boundary conditions.
+ */
+
+#pragma once
+
+#include "../bc.h"
+#include "../../core/printable.h"
+
+#include <memory>
+#include <string>
+
+namespace fem::bc {
+
+/**
+ * @brief Common ownership and diagnostics interface for Dirichlet conditions.
+ *
+ * Dirichlet conditions prescribe primary solution variables. Concrete solver
+ * domains provide the equation construction required for their unknowns.
+ */
+struct Dirichlet : BoundaryCondition, fem::Printable {
+    using Ptr = std::shared_ptr<Dirichlet>;
+
+    ~Dirichlet() override = default;
+    std::string str() const override = 0;
+};
+
+} // namespace fem::bc

--- a/src/bc/load.h
+++ b/src/bc/load.h
@@ -1,28 +1,23 @@
 /**
  * @file load.h
- * @brief Declares the polymorphic interface shared by all load types.
+ * @brief Declares the polymorphic interface shared by structural load types.
  *
- * A `Load` converts a physical loading definition into contributions to a
- * model field. Concrete implementations target nodes, surfaces, elements or
- * all structural elements and may optionally interpret their components in a
- * spatial coordinate system or scale them through a time-dependent amplitude.
- * The individual load formulations are declared in their dedicated headers,
- * which are included at the end of this umbrella header for convenient access.
+ * Structural loads are Neumann boundary data that assemble generalized nodal
+ * force contributions. Thermal Neumann conditions use their own scalar assembly
+ * interface under `bc/neumann` because convection contributes to both matrix and
+ * right-hand side.
  *
- * @see Load
+ * @see Neumann
  * @see LoadCollector
- * @see amplitude.h
- * @see load_collector.h
  * @author Finn Eggers
- * @date 06.03.2025
+ * @date 30.08.2026
  */
 
 #pragma once
 
 #include "amplitude.h"
-#include "bc.h"
+#include "neumann/neumann.h"
 
-#include "../core/printable.h"
 #include "../core/types_cls.h"
 #include "../core/types_eig.h"
 #include "../cos/coordinate_system.h"
@@ -41,48 +36,26 @@ namespace fem {
 namespace bc {
 
 /**
- * @brief Defines the common assembly interface for physical load conditions.
- *
- * Derived classes implement `apply()` to integrate or scatter their physical
- * load into the supplied boundary-condition field. The base class stores the
- * two optional modifiers common to several formulations: a coordinate system
- * for interpreting vector components and an amplitude for temporal scaling.
- * Each load also provides a compact printable representation for diagnostics
- * and model summaries.
+ * @brief Defines the common assembly interface for structural Neumann loads.
  */
-struct Load : public BoundaryCondition, public fem::Printable {
-    // Shared ownership type used by `LoadCollector` to hold heterogeneous load
-    // implementations in one contiguous collection of pointers.
+struct Load : public Neumann {
     using Ptr = std::shared_ptr<Load>;
 
-    // Optional coordinate system in which vector-valued load components are
-    // defined. A null pointer means that the stored components are already in
-    // the global model basis.
     cos::CoordinateSystem::Ptr orientation_ = nullptr;
+    Amplitude::Ptr             amplitude_   = nullptr;
 
-    // Optional scalar time history. A null pointer leaves the nominal load
-    // unchanged; concrete implementations may also explicitly bypass scaling.
-    Amplitude::Ptr amplitude_ = nullptr;
+    ~Load() override = default;
 
-    // Enable destruction through a `Load` pointer without requiring each
-    // collector to know the concrete load type.
-    virtual ~Load() = default;
+    virtual void apply(model::ModelData& model_data,
+                       model::Field&     bc,
+                       Precision         time,
+                       bool              ignore_amplitude = false) = 0;
 
-    // Assemble this load into `bc` using geometry and topology from
-    // `model_data`. `time` is passed to the optional amplitude, while
-    // `ignore_amplitude` requests assembly of the unscaled nominal load.
-    virtual void apply(model::ModelData& model_data, model::Field& bc, Precision time, bool ignore_amplitude = false) = 0;
-
-    // Return a compact one-line description containing the concrete load type,
-    // target region and the parameters relevant for diagnostics.
     std::string str() const override = 0;
 };
 } // namespace bc
 } // namespace fem
 
-// Expose all concrete load declarations through the common load header. The
-// concrete headers include this file themselves, relying on `#pragma once` to
-// terminate the cyclic umbrella inclusion after the base interface is known.
 #include "load_c.h"
 #include "load_d.h"
 #include "load_p.h"

--- a/src/bc/neumann/convection.cpp
+++ b/src/bc/neumann/convection.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file convection.cpp
+ * @brief Implements film-convection matrix and source assembly.
+ */
+
+#include "convection.h"
+#include "thermal_surface.h"
+
+#include "../../core/logging.h"
+#include "../../model/model_data.h"
+
+#include <sstream>
+
+namespace fem::bc {
+
+void Convection::apply(model::ModelData&   model_data,
+                       const SystemDofIds& thermal_dof_ids,
+                       TripletList&        matrix_terms,
+                       DynamicVector&      heat_source) const {
+    logging::error(region_ != nullptr,
+        "Convection: target surface region is not set");
+    logging::error(film_coefficient_ >= Precision(0),
+        "Convection: film coefficient must be non-negative");
+    logging::error(model_data.positions_reference != nullptr,
+        "Convection: reference positions field is not initialized");
+
+    const auto& positions = *model_data.positions_reference;
+
+    for (const ID surface_id : *region_) {
+        logging::error(surface_id >= 0
+                    && static_cast<Index>(surface_id) < static_cast<Index>(model_data.surfaces.size()),
+            "Convection: surface id ", surface_id, " is out of range");
+
+        const auto& surface = model_data.surfaces[static_cast<std::size_t>(surface_id)];
+        logging::error(surface != nullptr,
+            "Convection: surface ", surface_id, " is not initialized");
+
+        detail::visit_thermal_surface(*surface, [&](const auto& typed_surface) {
+            detail::assemble_convection_on_surface(
+                typed_surface,
+                positions,
+                thermal_dof_ids,
+                film_coefficient_,
+                ambient_temperature_,
+                matrix_terms,
+                heat_source
+            );
+        });
+    }
+}
+
+std::string Convection::str() const {
+    std::ostringstream os;
+    os << "CONVECTION: target=SFSET "
+       << (region_ ? region_->name : std::string("?"))
+       << " (" << (region_ ? static_cast<int>(region_->size()) : 0) << ")"
+       << ", h=" << film_coefficient_
+       << ", T_inf=" << ambient_temperature_;
+    return os.str();
+}
+
+} // namespace fem::bc

--- a/src/bc/neumann/convection.h
+++ b/src/bc/neumann/convection.h
@@ -1,0 +1,31 @@
+/**
+ * @file convection.h
+ * @brief Declares linear film-convection boundary conditions.
+ */
+
+#pragma once
+
+#include "thermal_load.h"
+#include "../../data/region.h"
+
+namespace fem::bc {
+
+/**
+ * @brief Exchanges heat with an ambient temperature through a film coefficient.
+ */
+struct Convection : ThermalLoad {
+    using Ptr = std::shared_ptr<Convection>;
+
+    model::SurfaceRegion::Ptr region_              = nullptr;
+    Precision                 film_coefficient_    = Precision(0);
+    Precision                 ambient_temperature_ = Precision(0);
+
+    void apply(model::ModelData&   model_data,
+               const SystemDofIds& thermal_dof_ids,
+               TripletList&        matrix_terms,
+               DynamicVector&      heat_source) const override;
+
+    std::string str() const override;
+};
+
+} // namespace fem::bc

--- a/src/bc/neumann/heat_flux.cpp
+++ b/src/bc/neumann/heat_flux.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file heat_flux.cpp
+ * @brief Implements consistent surface heat-flux assembly.
+ */
+
+#include "heat_flux.h"
+#include "thermal_surface.h"
+
+#include "../../core/logging.h"
+#include "../../model/model_data.h"
+
+#include <sstream>
+
+namespace fem::bc {
+
+void HeatFlux::apply(model::ModelData&   model_data,
+                     const SystemDofIds& thermal_dof_ids,
+                     TripletList&        matrix_terms,
+                     DynamicVector&      heat_source) const {
+    (void) matrix_terms;
+
+    logging::error(region_ != nullptr,
+        "HeatFlux: target surface region is not set");
+    logging::error(model_data.positions_reference != nullptr,
+        "HeatFlux: reference positions field is not initialized");
+
+    const auto& positions = *model_data.positions_reference;
+
+    for (const ID surface_id : *region_) {
+        logging::error(surface_id >= 0
+                    && static_cast<Index>(surface_id) < static_cast<Index>(model_data.surfaces.size()),
+            "HeatFlux: surface id ", surface_id, " is out of range");
+
+        const auto& surface = model_data.surfaces[static_cast<std::size_t>(surface_id)];
+        logging::error(surface != nullptr,
+            "HeatFlux: surface ", surface_id, " is not initialized");
+
+        detail::visit_thermal_surface(*surface, [&](const auto& typed_surface) {
+            detail::assemble_flux_on_surface(
+                typed_surface,
+                positions,
+                thermal_dof_ids,
+                flux_,
+                heat_source
+            );
+        });
+    }
+}
+
+std::string HeatFlux::str() const {
+    std::ostringstream os;
+    os << "HEATFLUX: target=SFSET "
+       << (region_ ? region_->name : std::string("?"))
+       << " (" << (region_ ? static_cast<int>(region_->size()) : 0) << ")"
+       << ", q=" << flux_;
+    return os.str();
+}
+
+} // namespace fem::bc

--- a/src/bc/neumann/heat_flux.h
+++ b/src/bc/neumann/heat_flux.h
@@ -1,0 +1,33 @@
+/**
+ * @file heat_flux.h
+ * @brief Declares prescribed scalar heat flux on surface regions.
+ */
+
+#pragma once
+
+#include "thermal_load.h"
+#include "../../data/region.h"
+
+namespace fem::bc {
+
+/**
+ * @brief Prescribes a normal heat flux entering the thermal domain.
+ *
+ * Positive values add heat to the model and therefore contribute positively to
+ * the steady-state thermal right-hand side.
+ */
+struct HeatFlux : ThermalLoad {
+    using Ptr = std::shared_ptr<HeatFlux>;
+
+    model::SurfaceRegion::Ptr region_ = nullptr;
+    Precision                 flux_   = Precision(0);
+
+    void apply(model::ModelData&   model_data,
+               const SystemDofIds& thermal_dof_ids,
+               TripletList&        matrix_terms,
+               DynamicVector&      heat_source) const override;
+
+    std::string str() const override;
+};
+
+} // namespace fem::bc

--- a/src/bc/neumann/neumann.h
+++ b/src/bc/neumann/neumann.h
@@ -1,0 +1,29 @@
+/**
+ * @file neumann.h
+ * @brief Declares the common base for natural boundary conditions.
+ */
+
+#pragma once
+
+#include "../bc.h"
+#include "../../core/printable.h"
+
+#include <memory>
+#include <string>
+
+namespace fem::bc {
+
+/**
+ * @brief Common ownership and diagnostics interface for Neumann conditions.
+ *
+ * Neumann conditions contribute generalized fluxes to a residual and may also
+ * contribute boundary tangent terms, as for thermal convection.
+ */
+struct Neumann : BoundaryCondition, fem::Printable {
+    using Ptr = std::shared_ptr<Neumann>;
+
+    ~Neumann() override = default;
+    std::string str() const override = 0;
+};
+
+} // namespace fem::bc

--- a/src/bc/neumann/thermal_load.h
+++ b/src/bc/neumann/thermal_load.h
@@ -1,0 +1,31 @@
+/**
+ * @file thermal_load.h
+ * @brief Declares the common interface for steady-state thermal Neumann data.
+ */
+
+#pragma once
+
+#include "neumann.h"
+#include "../../core/types_eig.h"
+
+namespace fem::model {
+struct ModelData;
+}
+
+namespace fem::bc {
+
+/**
+ * @brief Natural thermal boundary condition assembled into K_T and f_T.
+ */
+struct ThermalLoad : Neumann {
+    using Ptr = std::shared_ptr<ThermalLoad>;
+
+    ~ThermalLoad() override = default;
+
+    virtual void apply(model::ModelData&  model_data,
+                       const SystemDofIds& thermal_dof_ids,
+                       TripletList&        matrix_terms,
+                       DynamicVector&      heat_source) const = 0;
+};
+
+} // namespace fem::bc

--- a/src/bc/neumann/thermal_load_collector.h
+++ b/src/bc/neumann/thermal_load_collector.h
@@ -1,0 +1,26 @@
+/**
+ * @file thermal_load_collector.h
+ * @brief Declares named collections of thermal Neumann conditions.
+ */
+
+#pragma once
+
+#include "thermal_load.h"
+#include "../../data/collection.h"
+
+#include <string>
+#include <vector>
+
+namespace fem::bc {
+
+struct ThermalLoadCollector : model::Collection<ThermalLoad::Ptr> {
+    using Ptr = std::shared_ptr<ThermalLoadCollector>;
+    using model::Collection<ThermalLoad::Ptr>::add;
+
+    explicit ThermalLoadCollector(const std::string& name)
+        : model::Collection<ThermalLoad::Ptr>(name) {}
+
+    const std::vector<ThermalLoad::Ptr>& entries() const { return this->_data; }
+};
+
+} // namespace fem::bc

--- a/src/bc/neumann/thermal_surface.h
+++ b/src/bc/neumann/thermal_surface.h
@@ -1,0 +1,108 @@
+/**
+ * @file thermal_surface.h
+ * @brief Provides consistent scalar surface integration for thermal Neumann data.
+ */
+
+#pragma once
+
+#include "../../core/logging.h"
+#include "../../core/types_eig.h"
+#include "../../data/field.h"
+#include "../../model/geometry/surface/surface3.h"
+#include "../../model/geometry/surface/surface4.h"
+#include "../../model/geometry/surface/surface6.h"
+#include "../../model/geometry/surface/surface8.h"
+
+#include <utility>
+
+namespace fem::bc::detail {
+
+template<class Callback>
+void visit_thermal_surface(const model::SurfaceInterface& surface, Callback&& callback) {
+    if (const auto* typed = dynamic_cast<const model::Surface3*>(&surface)) {
+        callback(*typed);
+        return;
+    }
+    if (const auto* typed = dynamic_cast<const model::Surface4*>(&surface)) {
+        callback(*typed);
+        return;
+    }
+    if (const auto* typed = dynamic_cast<const model::Surface6*>(&surface)) {
+        callback(*typed);
+        return;
+    }
+    if (const auto* typed = dynamic_cast<const model::Surface8*>(&surface)) {
+        callback(*typed);
+        return;
+    }
+
+    logging::error(false,
+        "Thermal surface load: unsupported surface topology with ", surface.n_nodes, " nodes");
+}
+
+template<Index N>
+void assemble_flux_on_surface(const model::Surface<N>& surface,
+                              const model::Field&      positions,
+                              const SystemDofIds&      thermal_dof_ids,
+                              Precision                flux,
+                              DynamicVector&           heat_source) {
+    const auto coordinates = surface.node_coords_global(positions);
+    const auto& scheme      = surface.integration_scheme();
+
+    for (Index ip = 0; ip < scheme.count(); ++ip) {
+        const auto point = scheme.get_point(ip);
+        const auto shape = surface.shape_function(point.r, point.s);
+        const auto jac   = surface.jacobian(coordinates, point.r, point.s);
+        const Precision weighted_area = jac.col(0).cross(jac.col(1)).norm() * point.w;
+
+        for (Index i = 0; i < N; ++i) {
+            const ID node = surface.nodeIds[i];
+            const int dof = thermal_dof_ids(static_cast<Index>(node), 0);
+            logging::error(dof >= 0,
+                "Thermal surface load targets thermally inactive node ", node);
+            heat_source(dof) += shape(i) * flux * weighted_area;
+        }
+    }
+}
+
+template<Index N>
+void assemble_convection_on_surface(const model::Surface<N>& surface,
+                                    const model::Field&      positions,
+                                    const SystemDofIds&      thermal_dof_ids,
+                                    Precision                film,
+                                    Precision                ambient_temperature,
+                                    TripletList&              matrix_terms,
+                                    DynamicVector&           heat_source) {
+    const auto coordinates = surface.node_coords_global(positions);
+    const auto& scheme      = surface.integration_scheme();
+
+    for (Index ip = 0; ip < scheme.count(); ++ip) {
+        const auto point = scheme.get_point(ip);
+        const auto shape = surface.shape_function(point.r, point.s);
+        const auto jac   = surface.jacobian(coordinates, point.r, point.s);
+        const Precision weighted_area = jac.col(0).cross(jac.col(1)).norm() * point.w;
+
+        for (Index i = 0; i < N; ++i) {
+            const ID node_i = surface.nodeIds[i];
+            const int dof_i = thermal_dof_ids(static_cast<Index>(node_i), 0);
+            logging::error(dof_i >= 0,
+                "Convection targets thermally inactive node ", node_i);
+
+            heat_source(dof_i) += shape(i) * film * ambient_temperature * weighted_area;
+
+            for (Index j = 0; j < N; ++j) {
+                const ID node_j = surface.nodeIds[j];
+                const int dof_j = thermal_dof_ids(static_cast<Index>(node_j), 0);
+                logging::error(dof_j >= 0,
+                    "Convection targets thermally inactive node ", node_j);
+                matrix_terms.emplace_back(
+                    dof_i,
+                    dof_j,
+                    shape(i) * shape(j) * film * weighted_area
+                );
+            }
+        }
+    }
+}
+
+} // namespace fem::bc::detail

--- a/src/bc/support.h
+++ b/src/bc/support.h
@@ -11,6 +11,7 @@
  * `support.cpp`.
  *
  * @see Support
+ * @see SupportInterface
  * @see constraint::Equation
  * @see support.cpp
  * @author Finn Eggers
@@ -19,9 +20,9 @@
 
 #pragma once
 
-#include "../constraints/types/equation.h"
+#include "support_interface.h"
+
 #include "../core/core.h"
-#include "../core/printable.h"
 #include "../cos/coordinate_system.h"
 #include "../data/region.h"
 
@@ -43,7 +44,7 @@ namespace bc {
  * coordinate system, the selected local axis is expanded into its three global
  * directional coefficients before the equation is appended.
  */
-struct Support : public fem::Printable {
+struct Support : SupportInterface {
     // Pointer aliases keep the three supported region variants concise in the
     // public constructors and internal state.
     using NodeRegionPtr    = model::NodeRegion::Ptr;
@@ -74,7 +75,7 @@ struct Support : public fem::Printable {
     // Traverse the active target region and append all resulting constraint
     // equations to `equations`. Repeated nodes are processed as encountered by
     // the region topology.
-    void apply(model::ModelData& model_data, constraint::Equations& equations);
+    void apply(model::ModelData& model_data, constraint::Equations& equations) override;
 
     // Return a compact representation of the active target, prescribed degrees
     // of freedom and optional coordinate system.

--- a/src/bc/support_collector.cpp
+++ b/src/bc/support_collector.cpp
@@ -1,6 +1,11 @@
 /**
  * @file support_collector.cpp
- * @brief Implements collective support equation generation.
+ * @brief Implements construction of heterogeneous support collectors.
+ *
+ * The collector stores mechanical and thermal supports through their common
+ * interface. Type-selected equation generation remains in the header because
+ * the requesting load case supplies the concrete support type as a template
+ * argument.
  *
  * @author Finn Eggers
  * @date 19.08.2026
@@ -11,14 +16,6 @@
 namespace fem::bc {
 
 SupportCollector::SupportCollector(const std::string& name)
-    : model::Collection<Support>(name, true, false) {}
-
-constraint::Equations SupportCollector::get_equations(model::ModelData& model_data) {
-    constraint::Equations equations{};
-    for (Support& support : this->_data) {
-        support.apply(model_data, equations);
-    }
-    return equations;
-}
+    : model::Collection<SupportInterface::Ptr>(name) {}
 
 } // namespace fem::bc

--- a/src/bc/support_collector.h
+++ b/src/bc/support_collector.h
@@ -1,6 +1,15 @@
 /**
  * @file support_collector.h
- * @brief Declares a named collection of structural supports.
+ * @brief Declares named heterogeneous support collections.
+ *
+ * A support collector may own mechanical displacement constraints and thermal
+ * temperature constraints. Each load case collects only its compatible concrete
+ * support type so local degree-of-freedom identifiers are never interpreted by
+ * the wrong solver system.
+ *
+ * @see SupportInterface
+ * @see Support
+ * @see Temperature
  *
  * @author Finn Eggers
  * @date 19.08.2026
@@ -9,7 +18,9 @@
 #pragma once
 
 #include "../data/collection.h"
-#include "support.h"
+#include "support_interface.h"
+
+#include <type_traits>
 
 namespace fem {
 namespace model {
@@ -18,16 +29,45 @@ struct ModelData;
 
 namespace bc {
 
-struct SupportCollector : model::Collection<Support> {
+/**
+ * @brief Owns prescribed boundary conditions under one shared collector name.
+ *
+ * Mechanical and thermal support definitions coexist as polymorphic objects in
+ * insertion order. A requesting load case selects one concrete support type when
+ * it asks for equations; other definitions remain in the collector but do not
+ * contribute. This permits one input-level support namespace without confusing
+ * structural degree of freedom zero with the scalar thermal temperature degree
+ * of freedom.
+ */
+struct SupportCollector : model::Collection<SupportInterface::Ptr> {
     using Ptr = std::shared_ptr<SupportCollector>;
-    using model::Collection<Support>::add;
+    using model::Collection<SupportInterface::Ptr>::add;
 
     explicit SupportCollector(const std::string& name);
     ~SupportCollector() = default;
 
-    constraint::Equations get_equations(model::ModelData& model_data);
+    // Apply entries of the requested concrete support type in insertion order.
+    // Mechanical and thermal load cases use this filter with their respective
+    // support implementation so a shared collector remains solver-safe.
+    template<typename SupportType>
+    constraint::Equations get_equations(model::ModelData& model_data) {
+        // Restrict selection to concrete implementations of the common support
+        // contract at compile time.
+        static_assert(std::is_base_of_v<SupportInterface, SupportType>,
+            "SupportType must derive from SupportInterface");
 
-    const std::vector<Support>& entries() const { return this->_data; }
+        // Preserve collector order while applying only the requested support
+        // implementation.
+        constraint::Equations equations{};
+        for (const auto& support : this->_data) {
+            if (auto typed_support = std::dynamic_pointer_cast<SupportType>(support)) {
+                typed_support->apply(model_data, equations);
+            }
+        }
+        return equations;
+    }
+
+    const std::vector<SupportInterface::Ptr>& entries() const { return this->_data; }
 };
 
 } // namespace bc

--- a/src/bc/support_interface.h
+++ b/src/bc/support_interface.h
@@ -8,24 +8,20 @@
  * support collectors, while each load case selects the concrete support type
  * compatible with its own degree-of-freedom mapping.
  *
- * The interface deliberately owns no region or prescribed value. Concrete
- * support types retain those definitions and translate them into algebraic
- * equations compatible with their solver-specific degree-of-freedom mapping.
- *
+ * @see dirichlet/dirichlet.h
  * @see Support
  * @see Temperature
  * @see SupportCollector
  *
  * @author Finn Eggers
- * @date 29.08.2026
+ * @date 30.08.2026
  */
 
 #pragma once
 
-#include "bc.h"
+#include "dirichlet/dirichlet.h"
 
 #include "../constraints/types/equation.h"
-#include "../core/printable.h"
 
 #include <memory>
 #include <string>
@@ -37,30 +33,21 @@ struct ModelData;
 namespace fem::bc {
 
 /**
- * @brief Common polymorphic contract for essential boundary conditions.
+ * @brief Solver-equation interface shared by Dirichlet support conditions.
  *
- * A support interface converts one prescribed primary variable into constraint
- * equations over compiled model nodes. Mechanical and thermal definitions may
- * coexist in one collector even though local degree of freedom zero denotes
- * x-translation in the structural system and temperature in the thermal system.
- * The requesting load case therefore selects entries by their concrete type.
- *
- * Derived classes own their target region, prescribed values and any coordinate
- * conventions. They must append complete equations in deterministic order and
- * provide a concise printable representation for diagnostics.
+ * Mechanical and thermal definitions may coexist in one collector even though
+ * local degree of freedom zero denotes x-translation in the structural system
+ * and temperature in the thermal system. The requesting load case therefore
+ * selects entries by their concrete type.
  */
-struct SupportInterface : BoundaryCondition, Printable {
-    // Shared ownership type used by heterogeneous support collectors
+struct SupportInterface : Dirichlet {
     using Ptr = std::shared_ptr<SupportInterface>;
 
-    // Polymorphic destruction through collector-owned base pointers
-    virtual ~SupportInterface() = default;
+    ~SupportInterface() override = default;
 
-    // Translate the concrete prescribed values into solver equations over the
-    // compiled model topology.
-    virtual void apply(model::ModelData& model_data, constraint::Equations& equations) = 0;
+    virtual void apply(model::ModelData& model_data,
+                       constraint::Equations& equations) = 0;
 
-    // Return the concrete support definition for diagnostics
     std::string str() const override = 0;
 };
 

--- a/src/bc/support_interface.h
+++ b/src/bc/support_interface.h
@@ -1,0 +1,67 @@
+/**
+ * @file support_interface.h
+ * @brief Declares the common interface for prescribed solution variables.
+ *
+ * Support conditions impose essential boundary values on one physical solver
+ * system. Mechanical supports prescribe generalized displacements, whereas
+ * thermal supports prescribe scalar nodal temperatures. Both kinds share named
+ * support collectors, while each load case selects the concrete support type
+ * compatible with its own degree-of-freedom mapping.
+ *
+ * The interface deliberately owns no region or prescribed value. Concrete
+ * support types retain those definitions and translate them into algebraic
+ * equations compatible with their solver-specific degree-of-freedom mapping.
+ *
+ * @see Support
+ * @see Temperature
+ * @see SupportCollector
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
+
+#pragma once
+
+#include "bc.h"
+
+#include "../constraints/types/equation.h"
+#include "../core/printable.h"
+
+#include <memory>
+#include <string>
+
+namespace fem::model {
+struct ModelData;
+}
+
+namespace fem::bc {
+
+/**
+ * @brief Common polymorphic contract for essential boundary conditions.
+ *
+ * A support interface converts one prescribed primary variable into constraint
+ * equations over compiled model nodes. Mechanical and thermal definitions may
+ * coexist in one collector even though local degree of freedom zero denotes
+ * x-translation in the structural system and temperature in the thermal system.
+ * The requesting load case therefore selects entries by their concrete type.
+ *
+ * Derived classes own their target region, prescribed values and any coordinate
+ * conventions. They must append complete equations in deterministic order and
+ * provide a concise printable representation for diagnostics.
+ */
+struct SupportInterface : BoundaryCondition, Printable {
+    // Shared ownership type used by heterogeneous support collectors
+    using Ptr = std::shared_ptr<SupportInterface>;
+
+    // Polymorphic destruction through collector-owned base pointers
+    virtual ~SupportInterface() = default;
+
+    // Translate the concrete prescribed values into solver equations over the
+    // compiled model topology.
+    virtual void apply(model::ModelData& model_data, constraint::Equations& equations) = 0;
+
+    // Return the concrete support definition for diagnostics
+    std::string str() const override = 0;
+};
+
+} // namespace fem::bc

--- a/src/bc/thermal_temp.h
+++ b/src/bc/thermal_temp.h
@@ -12,6 +12,7 @@
  * thermal DOF mapping rather than the structural six-DOF mapping.
  *
  * @see Temperature
+ * @see SupportInterface
  * @see constraint::Equation
  * @see model::ThermalElement
  *
@@ -21,10 +22,8 @@
 
 #pragma once
 
-#include "bc.h"
+#include "support_interface.h"
 
-#include "../constraints/types/equation.h"
-#include "../core/printable.h"
 #include "../core/types_num.h"
 #include "../data/region.h"
 
@@ -51,7 +50,7 @@ namespace fem::bc {
  * represents the thermal unknown; the resulting equations are not structural
  * displacement constraints.
  */
-struct Temperature : BoundaryCondition, Printable {
+struct Temperature : SupportInterface {
     // Shared ownership type for prescribed-temperature definitions
     using Ptr = std::shared_ptr<Temperature>;
 
@@ -80,7 +79,7 @@ struct Temperature : BoundaryCondition, Printable {
 
     // Resolve the target to unique compiled nodes and append scalar thermal
     // Dirichlet equations with `temperature_` as their right-hand side.
-    void apply(model::ModelData& model_data, constraint::Equations& equations);
+    void apply(model::ModelData& model_data, constraint::Equations& equations) override;
 
     // Return the target region and prescribed scalar temperature.
     std::string str() const override;

--- a/src/io/reader/commands/register_conductivity.cpp
+++ b/src/io/reader/commands/register_conductivity.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file register_conductivity.cpp
+ * @brief Registers isotropic thermal-conductivity material data.
+ *
+ * The material-scoped `CONDUCTIVITY` command reads one positive isotropic
+ * conductivity and stores it on the material activated by the surrounding
+ * `MATERIAL` definition. Solid thermal elements consume this coefficient when
+ * assembling their conductivity matrix and recovering conductive heat flux.
+ *
+ * The command only defines constitutive input. Global thermal assembly remains
+ * the responsibility of `model::Model`, while steady-state solution control
+ * belongs to `loadcase::SteadyStateThermal`.
+ *
+ * @see material::Material
+ * @see model::ThermalElement
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
+
+#include "register_functions.h"
+#include "../../dsl/registry.h"
+
+#include "../../../core/logging.h"
+#include "../../../core/types_num.h"
+#include "../../../model/model.h"
+#include "../../dsl/condition.h"
+
+namespace fem::io::reader::commands {
+
+/**
+ * Registers constant isotropic conductivity for the active material.
+ *
+ * Exactly one strictly positive scalar is accepted. A positive coefficient is
+ * required by the initial steady-state thermal formulation because zero-valued
+ * elements would create disconnected algebraic temperature regions.
+ *
+ * @param registry DSL registry receiving the material child command.
+ * @param model Model owning the currently active material definition.
+ */
+void register_conductivity(fem::io::dsl::Registry& registry, model::Model& model) {
+    registry.command("CONDUCTIVITY", [&](fem::io::dsl::Command& command) {
+        // Conductivity belongs to the material selected by the parent scope
+        command.allow_if(fem::io::dsl::Condition::parent_is("MATERIAL"));
+        command.doc("Assign one positive isotropic thermal conductivity to the active material.");
+
+        // Parse and store the constant conductivity coefficient
+        command.variant(fem::io::dsl::Variant::make()
+            .segment(fem::io::dsl::Segment::make()
+                .range(fem::io::dsl::LineRange{}.min(1).max(1))
+                .pattern(fem::io::dsl::Pattern::make()
+                    .one<fem::Precision>().name("K").desc("Isotropic thermal conductivity")
+                )
+                .bind([&model](fem::Precision conductivity) {
+                    auto material = model._data->materials.get();
+                    logging::error(material != nullptr,
+                        "CONDUCTIVITY requires an active material context");
+                    logging::error(conductivity > Precision(0),
+                        "CONDUCTIVITY must be positive");
+                    material->set_thermal_conductivity(conductivity);
+                })
+            )
+        );
+    });
+}
+
+} // namespace fem::io::reader::commands

--- a/src/io/reader/commands/register_convection.cpp
+++ b/src/io/reader/commands/register_convection.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file register_convection.cpp
+ * @brief Registers linear film-convection boundary conditions.
+ */
+
+#include "register_functions.h"
+#include "../../dsl/registry.h"
+
+#include "../../../bc/neumann/convection.h"
+#include "../../../model/model.h"
+#include "../../dsl/condition.h"
+#include "../../dsl/keyword.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace fem::io::reader::commands {
+
+void register_convection(fem::io::dsl::Registry& registry, model::Model& model) {
+    registry.command("CONVECTION", [&](fem::io::dsl::Command& command) {
+        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "ASSEMBLY"}));
+        command.doc("Exchange heat with an ambient temperature through a film coefficient.");
+
+        command.keyword(
+            fem::io::dsl::KeywordSpec::make()
+                .key("LOAD_COLLECTOR").required()
+        );
+        command.on_enter([&model](const fem::io::dsl::Keys& keys) {
+            model._data->thermal_load_cols.activate(keys.raw("LOAD_COLLECTOR"));
+        });
+
+        command.variant(fem::io::dsl::Variant::make()
+            .segment(fem::io::dsl::Segment::make()
+                .range(fem::io::dsl::LineRange{}.min(1))
+                .pattern(fem::io::dsl::Pattern::make()
+                    .one<std::string>().name("TARGET").desc("Compiled surface or surface-set reference")
+                    .one<fem::Precision>().name("FILM_COEFFICIENT").desc("Film coefficient h")
+                    .one<fem::Precision>().name("AMBIENT_TEMPERATURE").desc("Ambient temperature")
+                )
+                .bind([&model](const std::string& target,
+                               fem::Precision film,
+                               fem::Precision ambient_temperature) {
+                    logging::error(film >= fem::Precision(0),
+                        "CONVECTION: film coefficient must be non-negative");
+
+                    model::SurfaceRegion::Ptr region;
+                    if (model._data->surface_sets.has(target)) {
+                        region = model._data->surface_sets.get(target);
+                    } else {
+                        region = std::make_shared<model::SurfaceRegion>("INTERNAL");
+                        region->add(model.compiled_surface_id(target));
+                    }
+
+                    auto load = std::make_shared<bc::Convection>();
+                    load->region_              = std::move(region);
+                    load->film_coefficient_    = film;
+                    load->ambient_temperature_ = ambient_temperature;
+
+                    logging::error(model._data->thermal_load_cols.get() != nullptr,
+                        "CONVECTION: no thermal load collector is active");
+                    model._data->thermal_load_cols.get()->add(std::move(load));
+                })
+            )
+        );
+    });
+}
+
+} // namespace fem::io::reader::commands

--- a/src/io/reader/commands/register_element.cpp
+++ b/src/io/reader/commands/register_element.cpp
@@ -2,22 +2,8 @@
  * @file register_element.cpp
  * @brief Registers part-local and unqualified assembly finite elements.
  *
- * The `ELEMENT` command dispatches supported FEMaster type names to their
- * concrete beam, truss, shell and solid element classes. Connectivity is stored
- * in the active semantic Part before compilation; unqualified root definitions
- * use the model's default part.
- *
- * One-node point-element labels `MASS`, `ROTARYI` and `SPRING1` share the
- * zero-dimensional `model::PointElement` implementation. Their physical mass,
- * rotary-inertia or ground-spring contribution is supplied later by the
- * corresponding element-property command.
- *
- * The registration preserves sparse user identifiers and natural connectivity.
- * Instance expansion and dense global enumeration are deliberately deferred to
- * `Model::compile()`.
- *
  * @author Finn Eggers
- * @date 26.08.2026
+ * @date 30.08.2026
  */
 
 #include "register_functions.h"
@@ -27,6 +13,7 @@
 #include <string>
 #include <utility>
 
+#include "../../../model/beam/b31.h"
 #include "../../../model/beam/b33.h"
 #include "../../../model/model.h"
 #include "../../../model/shell/frt_shell_s3.h"
@@ -40,6 +27,7 @@
 #include "../../../model/shell/s6.h"
 #include "../../../model/shell/s8.h"
 #include "../../../model/shell/s8_mitc.h"
+#include "../../../model/shell/shell_thermal.h"
 #include "../../../model/solid/c3d10.h"
 #include "../../../model/solid/c3d15.h"
 #include "../../../model/solid/c3d20.h"
@@ -49,6 +37,7 @@
 #include "../../../model/solid/c3d8.h"
 #include "../../../model/solid/c3d8r.h"
 #include "../../../model/element/point.h"
+#include "../../../model/truss/t3d2_thermal.h"
 #include "../../../model/truss/truss.h"
 #include "../../dsl/condition.h"
 #include "../../dsl/keyword.h"
@@ -70,26 +59,20 @@ inline void set_regular_element(model::Model& model, ID id, const std::array<ID,
     set_regular_element_impl<Elem, N>(model, id, nodes, std::make_index_sequence<N>{});
 }
 
-/**
- * @brief Registers sparse finite-element connectivity before model compilation.
- */
 void register_element(dsl::Registry& registry, model::Model& model) {
     registry.command("ELEMENT", [&](dsl::Command& command) {
-        // Elements may be defined directly, inside a Part or inside the assembly scope
         command.allow_if(dsl::Condition::parent_is({"ROOT", "PART", "ASSEMBLY"}));
 
-        // Define the destination element set and concrete element formulation
         command.keyword(
             dsl::KeywordSpec::make()
                 .key("ELSET").optional("EALL")
                 .key("TYPE").required().allowed({
                     "C3D4", "C3D5", "C3D6", "C3D8", "C3D8R", "C3D10", "C3D15", "C3D20", "C3D20R",
-                    "B33", "T3", "T3D2", "S3", "S4", "MITC4", "S6", "S8", "MITC8", "QSPT",
+                    "B31", "B33", "T3", "T3D2", "S3", "S4", "MITC4", "S6", "S8", "MITC8", "QSPT",
                     "MITC3FRT", "MITC4FRT", "MITC6FRT", "MITC8FRT", "MASS", "ROTARYI", "SPRING1"
                 })
         );
 
-        // Prepare the active element set before processing connectivity rows
         command.on_enter([&model](const dsl::Keys& keys) {
             logging::error(model._data != nullptr && !model._data->compiled,
                 "ELEMENT: elements cannot be added after compile()");
@@ -117,7 +100,7 @@ void register_element(dsl::Registry& registry, model::Model& model) {
             ) \
         );
 
-        // Register regular formulations with direct connectivity mapping
+        // Solid formulations already implement ThermalElement on the common solid base.
         FEM_ADD_ELEMENT_VARIANT("C3D4", C3D4, 4);
         FEM_ADD_ELEMENT_VARIANT("C3D6", C3D6, 6);
         FEM_ADD_ELEMENT_VARIANT("C3D8", C3D8, 8);
@@ -127,12 +110,15 @@ void register_element(dsl::Registry& registry, model::Model& model) {
         FEM_ADD_ELEMENT_VARIANT("C3D20", C3D20, 20);
         FEM_ADD_ELEMENT_VARIANT("C3D20R", C3D20R, 20);
 
+        // B31, T3D2, S3 and S4 add thermal conduction while reusing the existing
+        // mechanical formulations. The legacy FEMaster-only labels remain unchanged.
+        FEM_ADD_ELEMENT_VARIANT("B31", B31, 2);
         FEM_ADD_ELEMENT_VARIANT("B33", B33, 2);
         FEM_ADD_ELEMENT_VARIANT("T3", T3, 2);
-        FEM_ADD_ELEMENT_VARIANT("T3D2", T3, 2);
+        FEM_ADD_ELEMENT_VARIANT("T3D2", ThermalT3D2, 2);
 
-        FEM_ADD_ELEMENT_VARIANT("S3", S3, 3);
-        FEM_ADD_ELEMENT_VARIANT("S4", S4, 4);
+        FEM_ADD_ELEMENT_VARIANT("S3", ThermalS3, 3);
+        FEM_ADD_ELEMENT_VARIANT("S4", ThermalS4, 4);
         FEM_ADD_ELEMENT_VARIANT("S6", S6, 6);
         FEM_ADD_ELEMENT_VARIANT("S8", S8, 8);
         FEM_ADD_ELEMENT_VARIANT("QSPT", QSPT, 4);
@@ -143,14 +129,14 @@ void register_element(dsl::Registry& registry, model::Model& model) {
         FEM_ADD_ELEMENT_VARIANT("MITC8FRT", FRTShellS8, 8);
         FEM_ADD_ELEMENT_VARIANT("MITC8", MITC8, 8);
 
-        // All supported one-node concentrated formulations share PointElement.
         FEM_ADD_ELEMENT_VARIANT("MASS", PointElement, 1);
         FEM_ADD_ELEMENT_VARIANT("ROTARYI", PointElement, 1);
         FEM_ADD_ELEMENT_VARIANT("SPRING1", PointElement, 1);
 
 #undef FEM_ADD_ELEMENT_VARIANT
 
-        // Expand the five-node pyramid into the supported degenerate C3D8 topology
+        // C3D5 uses the established degenerate eight-node pyramid mapping and is
+        // therefore thermally capable through the C3D8 implementation as well.
         command.variant(dsl::Variant::make()
             .when(dsl::Condition::key_equals("TYPE", {"C3D5"}))
             .segment(dsl::Segment::make()

--- a/src/io/reader/commands/register_functions.h
+++ b/src/io/reader/commands/register_functions.h
@@ -2,20 +2,8 @@
  * @file register_functions.h
  * @brief Declares all native and Abaqus parser command registration functions.
  *
- * The command implementations are split into one translation unit per input
- * command. This header is the single declaration point used by the native and
- * Abaqus parsers as well as by those implementation files.
- *
- * Registration only constructs the DSL grammar. The parser owns semantic
- * execution order, while the registered callbacks translate parsed command
- * data into model and load-case state.
- *
- * @see Parser
- * @see ParserAbq
- * @see io::dsl::Registry
- *
  * @author Finn Eggers
- * @date 29.08.2026
+ * @date 30.08.2026
  */
 
 #pragma once
@@ -43,6 +31,7 @@ void register_cload            (fem::io::dsl::Registry& registry, fem::model::Mo
 void register_connector        (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_conductivity     (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_contact          (fem::io::dsl::Registry& registry, fem::model::Model& model);
+void register_convection       (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_coupling         (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_density          (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_dload            (fem::io::dsl::Registry& registry, fem::model::Model& model);
@@ -55,6 +44,7 @@ void register_end_part         (fem::io::dsl::Registry& registry, fem::model::Mo
 void register_equation         (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_field            (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_heading          (fem::io::dsl::Registry& registry);
+void register_heat_flux        (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_hyperelastic     (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_inertialload     (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_instance         (fem::io::dsl::Registry& registry, fem::model::Model& model);
@@ -112,7 +102,6 @@ void register_loadcase_write_every      (fem::io::dsl::Registry& registry, Parse
 
 namespace fem::io::reader::commands_abq {
 
-// Abaqus syntax translations backed directly by the FEMaster model
 void register_amplitude    (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_element      (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_expansion    (fem::io::dsl::Registry& registry, fem::model::Model& model);
@@ -120,7 +109,6 @@ void register_orientation  (fem::io::dsl::Registry& registry, fem::model::Model&
 void register_shell_section(fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_solid_section(fem::io::dsl::Registry& registry, fem::model::Model& model);
 
-// Abaqus commands operating on parser-owned step and load state
 void register_boundary (fem::io::dsl::Registry& registry, ParserAbq& parser);
 void register_cload    (fem::io::dsl::Registry& registry, ParserAbq& parser);
 void register_dload    (fem::io::dsl::Registry& registry, ParserAbq& parser);

--- a/src/io/reader/commands/register_functions.h
+++ b/src/io/reader/commands/register_functions.h
@@ -41,6 +41,7 @@ void register_assembly         (fem::io::dsl::Registry& registry);
 void register_beam_section     (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_cload            (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_connector        (fem::io::dsl::Registry& registry, fem::model::Model& model);
+void register_conductivity     (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_contact          (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_coupling         (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_density          (fem::io::dsl::Registry& registry, fem::model::Model& model);
@@ -76,6 +77,7 @@ void register_solid_section    (fem::io::dsl::Registry& registry, fem::model::Mo
 void register_spring           (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_support          (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_surface          (fem::io::dsl::Registry& registry, fem::model::Model& model);
+void register_temperature      (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_thermal_expansion(fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_tie              (fem::io::dsl::Registry& registry, fem::model::Model& model);
 void register_tload            (fem::io::dsl::Registry& registry, fem::model::Model& model);

--- a/src/io/reader/commands/register_heat_flux.cpp
+++ b/src/io/reader/commands/register_heat_flux.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file register_heat_flux.cpp
+ * @brief Registers prescribed surface heat fluxes.
+ */
+
+#include "register_functions.h"
+#include "../../dsl/registry.h"
+
+#include "../../../bc/neumann/heat_flux.h"
+#include "../../../model/model.h"
+#include "../../dsl/condition.h"
+#include "../../dsl/keyword.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace fem::io::reader::commands {
+
+void register_heat_flux(fem::io::dsl::Registry& registry, model::Model& model) {
+    registry.command("HEATFLUX", [&](fem::io::dsl::Command& command) {
+        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "ASSEMBLY"}));
+        command.doc("Prescribe a scalar surface heat flux; positive values add heat to the model.");
+
+        command.keyword(
+            fem::io::dsl::KeywordSpec::make()
+                .key("LOAD_COLLECTOR").required()
+        );
+        command.on_enter([&model](const fem::io::dsl::Keys& keys) {
+            model._data->thermal_load_cols.activate(keys.raw("LOAD_COLLECTOR"));
+        });
+
+        command.variant(fem::io::dsl::Variant::make()
+            .segment(fem::io::dsl::Segment::make()
+                .range(fem::io::dsl::LineRange{}.min(1))
+                .pattern(fem::io::dsl::Pattern::make()
+                    .one<std::string>().name("TARGET").desc("Compiled surface or surface-set reference")
+                    .one<fem::Precision>().name("FLUX").desc("Heat flux entering the model")
+                )
+                .bind([&model](const std::string& target, fem::Precision flux) {
+                    model::SurfaceRegion::Ptr region;
+                    if (model._data->surface_sets.has(target)) {
+                        region = model._data->surface_sets.get(target);
+                    } else {
+                        region = std::make_shared<model::SurfaceRegion>("INTERNAL");
+                        region->add(model.compiled_surface_id(target));
+                    }
+
+                    auto load = std::make_shared<bc::HeatFlux>();
+                    load->region_ = std::move(region);
+                    load->flux_   = flux;
+
+                    logging::error(model._data->thermal_load_cols.get() != nullptr,
+                        "HEATFLUX: no thermal load collector is active");
+                    model._data->thermal_load_cols.get()->add(std::move(load));
+                })
+            )
+        );
+    });
+}
+
+} // namespace fem::io::reader::commands

--- a/src/io/reader/commands/register_loadcase_begin.cpp
+++ b/src/io/reader/commands/register_loadcase_begin.cpp
@@ -36,6 +36,7 @@
 #include "../../../loadcase/linear_static_topo.h"
 #include "../../../loadcase/linear_transient.h"
 #include "../../../loadcase/nonlinear_static.h"
+#include "../../../loadcase/steady_state_thermal.h"
 
 namespace fem::io::reader::commands {
 
@@ -48,7 +49,7 @@ void register_loadcase_begin(fem::io::dsl::Registry& registry, Parser& parser) {
             fem::io::dsl::KeywordSpec::make()
                 .key("TYPE").required().allowed({
                     "LINEARSTATIC", "LINEARBUCKLING", "LINEARSTATICTOPO", "EIGENFREQ", "LINEARTRANSIENT",
-                    "LINEARHARMONIC", "NONLINEARSTATIC"})
+                    "LINEARHARMONIC", "NONLINEARSTATIC", "STEADYSTATETHERMAL"})
                 .key("NAME").optional()
         );
 
@@ -71,6 +72,8 @@ void register_loadcase_begin(fem::io::dsl::Registry& registry, Parser& parser) {
                 parser.begin_loadcase(std::make_unique<loadcase::Transient>());
             } else if (type == "LINEARHARMONIC") {
                 parser.begin_loadcase(std::make_unique<loadcase::LinearHarmonic>());
+            } else if (type == "STEADYSTATETHERMAL") {
+                parser.begin_loadcase(std::make_unique<loadcase::SteadyStateThermal>());
             } else {
                 logging::error(false,
                     "Unsupported loadcase type: ", type);

--- a/src/io/reader/commands/register_loadcase_constraintmethod.cpp
+++ b/src/io/reader/commands/register_loadcase_constraintmethod.cpp
@@ -3,9 +3,10 @@
  * @brief Registers constraint-transformation selection for structural analyses.
  *
  * `CONSTRAINTMETHOD` selects null-space projection, Lagrange multipliers or
- * elimination for the active supported load case. The command translates the
- * deck token into `ConstraintTransformer::Method` and applies it only to
- * analyses that expose a compatible constraint backend.
+ * elimination for the active supported structural or steady-state thermal load
+ * case. The command translates the deck token into
+ * `ConstraintTransformer::Method` and applies it only to analyses that expose a
+ * compatible constraint backend.
  *
  * Solver/backend compatibility remains documented by the command grammar and
  * is enforced by the corresponding load-case implementation during execution.
@@ -26,6 +27,7 @@
 #include "../../../loadcase/linear_harmonic.h"
 #include "../../../loadcase/linear_static.h"
 #include "../../../loadcase/nonlinear_static.h"
+#include "../../../loadcase/steady_state_thermal.h"
 
 namespace fem::io::reader::commands {
 
@@ -78,6 +80,10 @@ void register_loadcase_constraintmethod(fem::io::dsl::Registry& registry, Parser
                 return;
             }
             if (auto* lc = dynamic_cast<loadcase::LinearHarmonic*>(base)) {
+                lc->constraint_method = method;
+                return;
+            }
+            if (auto* lc = dynamic_cast<loadcase::SteadyStateThermal*>(base)) {
                 lc->constraint_method = method;
                 return;
             }

--- a/src/io/reader/commands/register_loadcase_loads.cpp
+++ b/src/io/reader/commands/register_loadcase_loads.cpp
@@ -2,17 +2,8 @@
  * @file register_loadcase_loads.cpp
  * @brief Registers load-collector selection for active load cases.
  *
- * The `LOADS` child command reads one or more load-collector names and appends
- * every non-empty token to the active analysis. It supports the static,
- * buckling, transient, harmonic and nonlinear load cases that assemble external
- * forces from named model collectors.
- *
- * Collector existence and formulation-specific load assembly remain load-case
- * responsibilities. This registration layer validates the active analysis type
- * and preserves the order in which collector names appear in the deck.
- *
  * @author Finn Eggers
- * @date 19.08.2026
+ * @date 30.08.2026
  */
 
 #include "register_functions.h"
@@ -30,11 +21,13 @@
 #include "../../../loadcase/linear_static.h"
 #include "../../../loadcase/linear_transient.h"
 #include "../../../loadcase/nonlinear_static.h"
+#include "../../../loadcase/steady_state_thermal.h"
 
 namespace fem::io::reader::commands {
 
 void register_loadcase_loads(fem::io::dsl::Registry& registry, Parser& parser) {
-    const auto append_tokens = [](const std::array<std::string, 16>& tokens, std::vector<std::string>& out) {
+    const auto append_tokens = [](const std::array<std::string, 16>& tokens,
+                                  std::vector<std::string>& out) {
         for (const auto& token : tokens) {
             if (!token.empty()) out.push_back(token);
         }
@@ -56,6 +49,10 @@ void register_loadcase_loads(fem::io::dsl::Registry& registry, Parser& parser) {
                     logging::error(base != nullptr,
                         "LOADS must appear inside *LOADCASE");
 
+                    if (auto* lc = dynamic_cast<loadcase::SteadyStateThermal*>(base)) {
+                        append_tokens(names, lc->loads);
+                        return;
+                    }
                     if (auto* lc = dynamic_cast<loadcase::LinearBuckling*>(base)) {
                         append_tokens(names, lc->loads);
                         return;

--- a/src/io/reader/commands/register_loadcase_solver.cpp
+++ b/src/io/reader/commands/register_loadcase_solver.cpp
@@ -28,6 +28,7 @@
 #include "../../../loadcase/linear_static_topo.h"
 #include "../../../loadcase/linear_transient.h"
 #include "../../../loadcase/nonlinear_static.h"
+#include "../../../loadcase/steady_state_thermal.h"
 
 namespace fem::io::reader::commands {
 
@@ -75,6 +76,7 @@ void register_loadcase_solver(fem::io::dsl::Registry& registry, Parser& parser) 
             if (configure(dynamic_cast<loadcase::NonlinearStatic*>(base))) return;
             if (configure(dynamic_cast<loadcase::LinearHarmonic*>(base))) return;
             if (configure(dynamic_cast<loadcase::Transient*>(base))) return;
+            if (configure(dynamic_cast<loadcase::SteadyStateThermal*>(base))) return;
 
             logging::error(false,
                 "SOLVER not supported for loadcase type ", base->type_name());

--- a/src/io/reader/commands/register_loadcase_supports.cpp
+++ b/src/io/reader/commands/register_loadcase_supports.cpp
@@ -4,8 +4,8 @@
  *
  * The `SUPPORTS` child command appends non-empty collector names to every
  * supported structural analysis, including static, buckling, eigenfrequency,
- * transient, harmonic and nonlinear formulations. Input order is retained so
- * downstream constraint construction remains deterministic.
+ * transient, harmonic, nonlinear and steady-state thermal formulations. Input
+ * order is retained so downstream constraint construction remains deterministic.
  *
  * Resolution of support, tie and coupling collectors and construction of the
  * resulting constraint equations remain responsibilities of the load case and
@@ -32,6 +32,7 @@
 #include "../../../loadcase/linear_static_topo.h"
 #include "../../../loadcase/linear_transient.h"
 #include "../../../loadcase/nonlinear_static.h"
+#include "../../../loadcase/steady_state_thermal.h"
 
 namespace fem::io::reader::commands {
 
@@ -83,6 +84,10 @@ void register_loadcase_supports(fem::io::dsl::Registry& registry, Parser& parser
                         return;
                     }
                     if (auto* lc = dynamic_cast<loadcase::Transient*>(base)) {
+                        append_tokens(names, lc->supps);
+                        return;
+                    }
+                    if (auto* lc = dynamic_cast<loadcase::SteadyStateThermal*>(base)) {
                         append_tokens(names, lc->supps);
                         return;
                     }

--- a/src/io/reader/commands/register_support.cpp
+++ b/src/io/reader/commands/register_support.cpp
@@ -74,7 +74,11 @@ void register_support(fem::io::dsl::Registry& registry, model::Model& model) {
                     for (Index i = 0; i < 6; ++i) {
                         constraint(i) = values[static_cast<std::size_t>(i)];
                     }
-                    model.add_support(bc::Support{std::move(region), constraint, std::move(orientation_ptr)});
+                    model.add_support(std::make_shared<bc::Support>(
+                        std::move(region),
+                        constraint,
+                        std::move(orientation_ptr)
+                    ));
                 })
             )
         );

--- a/src/io/reader/commands/register_temperature.cpp
+++ b/src/io/reader/commands/register_temperature.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file register_temperature.cpp
+ * @brief Registers prescribed nodal temperatures as support conditions.
+ *
+ * The root- and assembly-level `TEMPERATURE` command targets compiled nodes or
+ * node regions and stores each prescription in the named common support
+ * collector. Mechanical and thermal support definitions share collector
+ * ownership through `bc::SupportInterface`; thermal load cases later select
+ * only `bc::Temperature` entries.
+ *
+ * Temperature values are absolute scalar primary variables. They are therefore
+ * essential boundary conditions rather than thermal loads and do not contribute
+ * to a heat-source right-hand side.
+ *
+ * @see bc::Temperature
+ * @see bc::SupportCollector
+ * @see model::Model::add_support
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
+
+#include "register_functions.h"
+#include "../../dsl/registry.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "../../../bc/thermal_temp.h"
+#include "../../../model/model.h"
+#include "../../dsl/condition.h"
+#include "../../dsl/keyword.h"
+
+namespace fem::io::reader::commands {
+
+/**
+ * Registers prescribed absolute temperatures for compiled node targets.
+ *
+ * Command entry activates the requested shared support collector. Every data row
+ * resolves its target as an existing compiled node region or as one scalar node
+ * reference and transfers a polymorphic `bc::Temperature` to that collector.
+ *
+ * @param registry DSL registry receiving the temperature command.
+ * @param model Compiled model providing node resolution and support storage.
+ */
+void register_temperature(fem::io::dsl::Registry& registry, model::Model& model) {
+    registry.command("TEMPERATURE", [&](fem::io::dsl::Command& command) {
+        // Prescribed temperatures operate only on compiled assembly nodes
+        command.allow_if(fem::io::dsl::Condition::parent_is({"ROOT", "ASSEMBLY"}));
+        command.doc("Prescribe absolute nodal temperatures in a named support collector.");
+
+        // Select the common collector receiving all rows of this command
+        command.keyword(
+            fem::io::dsl::KeywordSpec::make()
+                .key("SUPPORT_COLLECTOR")
+                    .alternative("SUPPORTCOLLECTOR")
+                    .alternative("NAME")
+                    .required()
+                    .doc("Common support collector receiving the temperatures")
+        );
+        command.on_enter([&model](const fem::io::dsl::Keys& keys) {
+            model._data->supp_cols.activate(keys.raw("SUPPORT_COLLECTOR"));
+        });
+
+        // Resolve node-set or scalar-node targets and store absolute values
+        command.variant(fem::io::dsl::Variant::make()
+            .segment(fem::io::dsl::Segment::make()
+                .range(fem::io::dsl::LineRange{}.min(1))
+                .pattern(fem::io::dsl::Pattern::make()
+                    .one<std::string>().name("TARGET").desc("Compiled node or node-set reference")
+                    .one<fem::Precision>().name("TEMPERATURE").desc("Absolute prescribed temperature")
+                )
+                .bind([&model](const std::string& target, fem::Precision temperature) {
+                    model::NodeRegion::Ptr region;
+                    if (model._data->node_sets.has(target)) {
+                        region = model._data->node_sets.get(target);
+                    } else {
+                        region = std::make_shared<model::NodeRegion>("INTERNAL");
+                        region->add(model.compiled_node_id(target));
+                    }
+
+                    model.add_support(std::make_shared<bc::Temperature>(
+                        std::move(region),
+                        temperature
+                    ));
+                })
+            )
+        );
+    });
+}
+
+} // namespace fem::io::reader::commands

--- a/src/io/reader/commands_abq/register_boundary.cpp
+++ b/src/io/reader/commands_abq/register_boundary.cpp
@@ -101,7 +101,11 @@ void register_boundary(fem::io::dsl::Registry& registry, ParserAbq& parser) {
 
                         auto region = std::make_shared<model::NodeRegion>("INTERNAL");
                         region->add(node_id);
-                        model.add_support(bc::Support{std::move(region), values, std::move(orientation)});
+                        model.add_support(std::make_shared<bc::Support>(
+                            std::move(region),
+                            values,
+                            std::move(orientation)
+                        ));
                     };
 
                     if (model._data->node_sets.has(target)) {

--- a/src/io/reader/parser.cpp
+++ b/src/io/reader/parser.cpp
@@ -2,25 +2,8 @@
  * @file parser.cpp
  * @brief Implements one-shot parsing and explicit FEMaster deck processing.
  *
- * The input file is parsed exactly once into `dsl::Deck`. Semantic model
- * construction then follows a visible dependency order: global definitions,
- * Part-local topology, Instances, `Model::compile()`, assembly materialization,
- * compiled model features and finally load cases. Scope-sensitive commands are
- * selected from their stored parent nodes instead of being replayed in parser
- * stages.
- *
- * The registered command callbacks remain the semantic implementation.
- * `ParsedCommand::enter()`, `execute()` and `leave()` control when those existing
- * callbacks run; syntax validation, variant selection and data aggregation have
- * already completed in `dsl::DeckParser`.
- *
- * @see Parser
- * @see io::dsl::Deck
- * @see io::dsl::DeckParser
- * @see model::Model::compile
- *
  * @author Finn Eggers
- * @date 26.08.2026
+ * @date 30.08.2026
  */
 
 #include "parser.h"
@@ -39,78 +22,44 @@
 
 namespace fem::io::reader {
 
-/**
- * Constructs an idle parser and prepares the native FEMaster documentation grammar.
- */
 Parser::Parser()
-    : model_(std::make_shared<model::Model>()),
-      writer_("") {
+    : model_(std::make_shared<model::Model>()), writer_("") {
     configure_documentation_registry();
 }
 
 Parser::~Parser() = default;
 
-/**
- * Parses one complete input deck and executes its semantic commands afterwards.
- *
- * Every run owns one registry for the entire parse/process lifetime. This is
- * required because parsed command and segment pointers refer directly to that
- * registry. The file itself is consumed only once; all later dependency ordering
- * operates on the in-memory deck representation.
- *
- * @param input_path Input deck parsed exactly once.
- * @param output_path Optional base path for result files.
- * @param writer_formats Result formats enabled for analysis output.
- */
 void Parser::run(const std::string& input_path,
                  const std::string& output_path,
                  const io::writer::WriterFileFormats& writer_formats) {
-    // Reset all mutable state so each run represents an independent deck.
     model_ = std::make_shared<model::Model>();
     active_loadcase_.reset();
     next_loadcase_id_ = 1;
 
-    // Register the complete grammar once and parse the complete source once.
     io::dsl::Registry registry;
     register_commands(registry);
 
     io::dsl::File       file(input_path);
     io::dsl::DeckParser deck_parser(registry);
     const io::dsl::Deck deck = deck_parser.parse(file);
-
-    // Semantic dependencies are now explicit and independent of source order.
     process_deck(deck, input_path, output_path, writer_formats);
 }
 
-/**
- * Executes the parsed native FEMaster deck in explicit model-dependency order.
- *
- * The function deliberately spells out the semantic order from top to bottom.
- * Loops only iterate repeated input scopes such as MATERIAL, PART, ASSEMBLY,
- * COUPLING and LOADCASE; command ordering inside each scope remains visible at
- * the call site. `Model::compile()` forms the one-way boundary between sparse
- * Part/Instance topology and dense assembly materialization.
- */
-void Parser::process_deck(const io::dsl::Deck&                  deck,
-                          const std::string&                    input_path,
-                          const std::string&                    output_path,
+void Parser::process_deck(const io::dsl::Deck&                 deck,
+                          const std::string&                   input_path,
+                          const std::string&                   output_path,
                           const io::writer::WriterFileFormats& writer_formats) {
     const auto& root = deck.root();
 
-    // ---------------------------------------------------------------------
-    // Global definitions required by sections and later load definitions
-    // ---------------------------------------------------------------------
     root.execute_children("HEADING");
 
     for (const auto* material : root.children("MATERIAL")) {
         material->enter();
-
         material->execute_children("ELASTIC");
         material->execute_children("HYPERELASTIC");
         material->execute_children("DENSITY");
         material->execute_children("CONDUCTIVITY");
         material->execute_children("THERMALEXPANSION");
-
         material->leave();
     }
 
@@ -118,77 +67,52 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
     root.execute_children("ORIENTATION");
     root.execute_children("AMPLITUDE");
 
-    // ---------------------------------------------------------------------
-    // Default-Part topology before Model::compile()
-    // ---------------------------------------------------------------------
+    // Default Part.
     root.execute_children("NODE");
     root.execute_children("ELEMENT");
-
     root.execute_children("NSET");
     root.execute_children("ELSET");
     root.execute_children("SURFACE");
     root.execute_children("SFSET");
-
     root.execute_children("SOLIDSECTION");
     root.execute_children("BEAMSECTION");
     root.execute_children("TRUSSSECTION");
     root.execute_children("SHELLSECTION");
-
     root.execute_children("MASS");
     root.execute_children("ROTARYINERTIA");
     root.execute_children("SPRING");
 
-    // ---------------------------------------------------------------------
-    // Explicit Part topology before Model::compile()
-    // ---------------------------------------------------------------------
+    // Explicit Parts.
     for (const auto* part : root.children("PART")) {
         part->enter();
-
         part->execute_children("NODE");
         part->execute_children("ELEMENT");
-
         part->execute_children("NSET");
         part->execute_children("ELSET");
         part->execute_children("SURFACE");
         part->execute_children("SFSET");
-
         part->execute_children("SOLIDSECTION");
         part->execute_children("BEAMSECTION");
         part->execute_children("TRUSSSECTION");
         part->execute_children("SHELLSECTION");
-
         part->execute_children("MASS");
         part->execute_children("ROTARYINERTIA");
         part->execute_children("SPRING");
-
         part->leave();
     }
 
-    // ---------------------------------------------------------------------
-    // Assembly orphan topology before Model::compile()
-    // ---------------------------------------------------------------------
     for (const auto* assembly : root.children("ASSEMBLY")) {
         assembly->execute_children("NODE");
         assembly->execute_children("ELEMENT");
     }
 
-    // ---------------------------------------------------------------------
-    // Instances depend on completed Parts and orphan assembly topology
-    // ---------------------------------------------------------------------
     root.execute_children("INSTANCE");
-
     for (const auto* assembly : root.children("ASSEMBLY")) {
         assembly->execute_children("INSTANCE");
     }
 
-    // ---------------------------------------------------------------------
-    // Transition from sparse topology to dense assembly data
-    // ---------------------------------------------------------------------
     model_->compile();
 
-    // ---------------------------------------------------------------------
-    // Assembly regions, properties and dense fields
-    // ---------------------------------------------------------------------
     root.execute_children("FIELD");
     root.execute_children("NORMAL");
 
@@ -197,32 +121,24 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
         assembly->execute_children("ELSET");
         assembly->execute_children("SURFACE");
         assembly->execute_children("SFSET");
-
         assembly->execute_children("MASS");
         assembly->execute_children("ROTARYINERTIA");
         assembly->execute_children("SPRING");
-
         assembly->execute_children("FIELD");
         assembly->execute_children("NORMAL");
     }
 
-    // Complete reference normals before constraints or analyses consume shells.
     model_->build_shell_element_normals();
-
-    // ---------------------------------------------------------------------
-    // Compiled model features
-    // ---------------------------------------------------------------------
     root.execute_children("POINTMASS");
 
-    // ---------------------------------------------------------------------
-    // Root-level collectors and constraints
-    // ---------------------------------------------------------------------
+    // Root-level Dirichlet and Neumann conditions.
     root.execute_children("SUPPORT");
     root.execute_children("TEMPERATURE");
-
     root.execute_children("CLOAD");
     root.execute_children("DLOAD");
     root.execute_children("PLOAD");
+    root.execute_children("HEATFLUX");
+    root.execute_children("CONVECTION");
     root.execute_children("TLOAD");
     root.execute_children("VLOAD");
     root.execute_children("INERTIALLOAD");
@@ -233,20 +149,18 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
     root.execute_children("CONTACT");
     root.execute_children("EQUATION");
 
-    // ---------------------------------------------------------------------
-    // Assembly-level collectors and constraints
-    // ---------------------------------------------------------------------
+    // Assembly-level Dirichlet and Neumann conditions.
     for (const auto* assembly : root.children("ASSEMBLY")) {
         assembly->execute_children("SUPPORT");
         assembly->execute_children("TEMPERATURE");
-
         assembly->execute_children("CLOAD");
         assembly->execute_children("DLOAD");
         assembly->execute_children("PLOAD");
+        assembly->execute_children("HEATFLUX");
+        assembly->execute_children("CONVECTION");
         assembly->execute_children("TLOAD");
         assembly->execute_children("VLOAD");
         assembly->execute_children("INERTIALLOAD");
-
         assembly->execute_children("RBM");
         assembly->execute_children("CONNECTOR");
         assembly->execute_children("TIE");
@@ -254,51 +168,35 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
         assembly->execute_children("EQUATION");
     }
 
-    // ---------------------------------------------------------------------
-    // Couplings
-    // ---------------------------------------------------------------------
     for (const auto* coupling : root.children("COUPLING")) {
         coupling->enter();
-
         coupling->execute_children("KINEMATIC");
         coupling->execute_children("DISTRIBUTING");
-
         coupling->leave();
     }
 
     for (const auto* assembly : root.children("ASSEMBLY")) {
         for (const auto* coupling : assembly->children("COUPLING")) {
             coupling->enter();
-
             coupling->execute_children("KINEMATIC");
             coupling->execute_children("DISTRIBUTING");
-
             coupling->leave();
         }
     }
 
     root.execute_children("OVERVIEW");
 
-    // ---------------------------------------------------------------------
-    // Result writers and load-case execution
-    // ---------------------------------------------------------------------
     initialize_writers(input_path, output_path, writer_formats);
-
     for (const auto* loadcase : root.children("LOADCASE")) {
         loadcase->enter();
         loadcase->execute_children();
         loadcase->leave();
     }
-
     close_writers();
 }
 
-/**
- * Initializes enabled result writers from the requested output path and publishes
- * the completely materialized model before any load case starts writing frames.
- */
-void Parser::initialize_writers(const std::string&                    input_path,
-                                const std::string&                    output_path,
+void Parser::initialize_writers(const std::string&                   input_path,
+                                const std::string&                   output_path,
                                 const io::writer::WriterFileFormats& writer_formats) {
     std::string writer_base = output_path.empty() ? input_path : output_path;
     for (const std::string& ext : {std::string(".res"), std::string(".frd"), std::string(".inp")}) {
@@ -313,16 +211,10 @@ void Parser::initialize_writers(const std::string&                    input_path
     writer_.write_model_data(*model_->_data);
 }
 
-/**
- * Flushes and closes every enabled result writer after semantic analysis processing.
- */
 void Parser::close_writers() {
     writer_.close();
 }
 
-/**
- * Prints one requested view of the registered FEMaster command grammar.
- */
 void Parser::document(const DocOptions& opts) const {
     using A = DocOptions::Action;
     using F = DocOptions::Format;
@@ -343,29 +235,20 @@ void Parser::document(const DocOptions& opts) const {
     }
 }
 
-/**
- * Returns the mutable model currently constructed or analyzed by the parser.
- */
 model::Model& Parser::model() {
-    logging::error(model_ != nullptr,
-        "Parser: model is not initialized");
+    logging::error(model_ != nullptr, "Parser: model is not initialized");
     return *model_;
 }
 
-/**
- * Returns the model currently constructed or analyzed by the parser.
- */
 const model::Model& Parser::model() const {
-    logging::error(model_ != nullptr,
-        "Parser: model is not initialized");
+    logging::error(model_ != nullptr, "Parser: model is not initialized");
     return *model_;
 }
 
-const io::dsl::Registry& Parser::registry() const { return documentation_registry_; }
+const io::dsl::Registry& Parser::registry() const {
+    return documentation_registry_;
+}
 
-/**
- * Activates a load case and supplies its parser-owned analysis context.
- */
 void Parser::begin_loadcase(loadcase::LoadCase::Ptr loadcase) {
     logging::error(active_loadcase_ == nullptr,
         "Parser: nested load cases are not supported");
@@ -380,9 +263,6 @@ void Parser::begin_loadcase(loadcase::LoadCase::Ptr loadcase) {
     active_loadcase_ = std::move(loadcase);
 }
 
-/**
- * Completes and executes the active load case.
- */
 void Parser::end_loadcase() {
     logging::error(active_loadcase_ != nullptr,
         "Parser: cannot end a load case when none is active");
@@ -391,35 +271,21 @@ void Parser::end_loadcase() {
     loadcase->run();
 }
 
-/**
- * Returns the load case currently configured by consecutive parser commands.
- */
 loadcase::LoadCase* Parser::active_loadcase() {
     return active_loadcase_.get();
 }
 
-/**
- * Rebuilds the persistent registry used for command-language documentation.
- */
 void Parser::configure_documentation_registry() {
     documentation_registry_ = io::dsl::Registry{};
     register_commands(documentation_registry_);
 }
 
-/**
- * Registers the complete native FEMaster command grammar exactly once per run.
- *
- * Registration describes syntax and semantic callbacks only. No parser stage or
- * command activation mode is attached to the grammar; execution timing belongs
- * exclusively to `process_deck()`.
- */
 void Parser::register_commands(io::dsl::Registry& registry) {
     logging::error(model_ != nullptr,
         "Parser: model must exist before registering commands");
 
     auto& mdl = *model_;
 
-    // Semantic Part/Instance topology and scope-aware assembly commands
     commands::register_part        (registry, mdl);
     commands::register_end_part    (registry, mdl);
     commands::register_assembly    (registry);
@@ -433,7 +299,6 @@ void Parser::register_commands(io::dsl::Registry& registry) {
     commands::register_surface     (registry, mdl);
     commands::register_sfset       (registry, mdl);
 
-    // Root model and native load-case terminator scopes
     registry.command("MODEL", [](io::dsl::Command& command) {
         command.allow_if(io::dsl::Condition::parent_is("ROOT"));
         command.keyword(io::dsl::KeywordSpec::make().key("NAME").optional());
@@ -445,7 +310,6 @@ void Parser::register_commands(io::dsl::Registry& registry) {
         command.variant(io::dsl::Variant::make());
     });
 
-    // Field, material, profile and section definitions
     commands::register_heading(registry);
     commands::register_field(registry, mdl);
     commands::register_normal(registry, mdl);
@@ -465,10 +329,11 @@ void Parser::register_commands(io::dsl::Registry& registry) {
     commands::register_rotary_inertia(registry, mdl);
     commands::register_spring(registry, mdl);
 
-    // Loads, constraints, features and model diagnostics
     commands::register_cload(registry, mdl);
     commands::register_dload(registry, mdl);
     commands::register_pload(registry, mdl);
+    commands::register_heat_flux(registry, mdl);
+    commands::register_convection(registry, mdl);
     commands::register_tload(registry, mdl);
     commands::register_vload(registry, mdl);
     commands::register_inertialload(registry, mdl);
@@ -484,7 +349,6 @@ void Parser::register_commands(io::dsl::Registry& registry) {
     commands::register_overview(registry, mdl);
     commands::register_equation(registry, mdl);
 
-    // Load-case creation, solver settings and result requests
     commands::register_loadcase_begin(registry, *this);
     commands::register_loadcase_supports(registry, *this);
     commands::register_loadcase_loads(registry, *this);

--- a/src/io/reader/parser.cpp
+++ b/src/io/reader/parser.cpp
@@ -108,6 +108,7 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
         material->execute_children("ELASTIC");
         material->execute_children("HYPERELASTIC");
         material->execute_children("DENSITY");
+        material->execute_children("CONDUCTIVITY");
         material->execute_children("THERMALEXPANSION");
 
         material->leave();
@@ -217,6 +218,7 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
     // Root-level collectors and constraints
     // ---------------------------------------------------------------------
     root.execute_children("SUPPORT");
+    root.execute_children("TEMPERATURE");
 
     root.execute_children("CLOAD");
     root.execute_children("DLOAD");
@@ -236,6 +238,7 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
     // ---------------------------------------------------------------------
     for (const auto* assembly : root.children("ASSEMBLY")) {
         assembly->execute_children("SUPPORT");
+        assembly->execute_children("TEMPERATURE");
 
         assembly->execute_children("CLOAD");
         assembly->execute_children("DLOAD");
@@ -450,6 +453,7 @@ void Parser::register_commands(io::dsl::Registry& registry) {
     commands::register_elastic(registry, mdl);
     commands::register_hyperelastic(registry, mdl);
     commands::register_density(registry, mdl);
+    commands::register_conductivity(registry, mdl);
     commands::register_thermal_expansion(registry, mdl);
     commands::register_orientation(registry, mdl);
     commands::register_profile(registry, mdl);
@@ -470,6 +474,7 @@ void Parser::register_commands(io::dsl::Registry& registry) {
     commands::register_inertialload(registry, mdl);
     commands::register_rbm(registry, mdl);
     commands::register_support(registry, mdl);
+    commands::register_temperature(registry, mdl);
     commands::register_amplitude(registry, mdl);
     commands::register_connector(registry, mdl);
     commands::register_coupling(registry, mdl);

--- a/src/io/writer/writer_frd.cpp
+++ b/src/io/writer/writer_frd.cpp
@@ -3,7 +3,7 @@
  * @brief Implements the ASCII CalculiX/CGX FRD result writer.
  *
  * The writer emits compiled FEMaster nodes, supported structural elements and
- * NODE-domain result fields in CalculiX FRD syntax.
+ * NODE-domain structural or thermal result fields in CalculiX FRD syntax.
  *
  * FEMaster solver topology uses dense node identifiers. When model data is
  * written, the semantic reverse mapping retained by `ModelData` is evaluated
@@ -328,6 +328,12 @@ const FRDField& frd_field(const std::string& field_name) {
     }
 
     static const std::vector<FRDField> definitions{
+        {
+            {"TEMPERATURE", "NDTEMP"}, "NDTEMP",
+            {
+                FRDComponent::scalar("T", 1)
+            }
+        },
         {
             {"DISPLACEMENT", "DISP", "MODESHAPE", "BUCKLINGMODE"}, "DISP",
             {

--- a/src/loadcase/steady_state_thermal.cpp
+++ b/src/loadcase/steady_state_thermal.cpp
@@ -1,0 +1,210 @@
+/**
+ * @file steady_state_thermal.cpp
+ * @brief Implements linear steady-state heat-conduction analysis.
+ *
+ * The implementation enumerates one temperature unknown per thermally active
+ * node, assembles the global conductivity matrix, imposes prescribed absolute
+ * temperatures through the common constraint transformer and solves the zero-
+ * source stationary balance. The recovered temperature drives element-level
+ * Fourier heat-flux evaluation before both result fields are written.
+ *
+ * Thermal loads and capacity terms are deliberately absent. They belong to
+ * future source/flux/convection conditions and transient thermal analysis.
+ *
+ * @see SteadyStateThermal
+ * @see model::Model::build_conductivity_matrix
+ * @see model::Model::compute_heat_flux
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
+
+#include "steady_state_thermal.h"
+
+#include "../core/logging.h"
+#include "../core/timer.h"
+#include "../model/model.h"
+
+#include <cmath>
+#include <memory>
+
+namespace fem::loadcase {
+
+using constraint::ConstraintTransformer;
+
+/**
+ * Solves the constrained stationary heat equation and writes thermal results.
+ *
+ * The analysis performs the following phases:
+ *
+ * - assign compiled solid sections and enumerate scalar thermal unknowns,
+ * - collect only `bc::Temperature` entries from the selected support collectors,
+ * - assemble the conductivity operator and its zero heat-source right-hand side,
+ * - transform and solve the affine constrained system,
+ * - recover a one-component nodal temperature field,
+ * - evaluate integration-point heat flux through Fourier's law,
+ * - write `TEMPERATURE` and `HEAT_FLUX` as one static result frame.
+ *
+ * A missing temperature constraint leaves the zero-source conductivity problem
+ * singular and is rejected explicitly. Additional disconnected components still
+ * require one prescribed temperature each; the selected sparse solver diagnoses
+ * any remaining singularity.
+ */
+void SteadyStateThermal::run() {
+    // Print the analysis header and validate parser-assigned dependencies
+    logging::info(true, "");
+    logging::info(true, "");
+    logging::info(true, "===============================================================================================");
+    logging::info(true, "STEADY-STATE THERMAL ANALYSIS");
+    logging::info(true, "===============================================================================================");
+    logging::info(true, "");
+
+    logging::error(model != nullptr,
+        "STEADYSTATETHERMAL: model is not initialized");
+    logging::error(writer != nullptr,
+        "STEADYSTATETHERMAL: result writer is not initialized");
+
+    // Bind material-bearing sections before thermal element evaluation
+    model->assign_sections();
+
+    // Enumerate one active temperature unknown per thermal element node
+    auto thermal_dof_ids = Timer::measure(
+        [&]() { return model->build_thermal_index_matrix(); },
+        "generating thermal DOF index matrix"
+    );
+    logging::error(thermal_dof_ids.rows() > 0,
+        "STEADYSTATETHERMAL: compiled model contains no nodes");
+    const int max_thermal_dof = thermal_dof_ids.maxCoeff();
+    logging::error(max_thermal_dof >= 0,
+        "STEADYSTATETHERMAL: model contains no thermally active element nodes");
+    const Index active_temperatures = static_cast<Index>(max_thermal_dof + 1);
+
+    // Collect absolute temperature constraints from common support collectors
+    auto groups = Timer::measure(
+        [&]() { return model->collect_temperature_constraints(supps); },
+        "collecting prescribed temperatures"
+    );
+    report_constraint_groups(groups);
+    auto equations = groups.flatten();
+    logging::error(!equations.empty(),
+        "STEADYSTATETHERMAL: at least one prescribed temperature is required");
+
+    // Assemble the symmetric conduction operator and the zero source vector
+    auto conductivity = Timer::measure(
+        [&]() { return model->build_conductivity_matrix(thermal_dof_ids); },
+        "constructing thermal conductivity matrix K_T"
+    );
+    logging::error(conductivity.rows() == active_temperatures
+                && conductivity.cols() == active_temperatures,
+        "STEADYSTATETHERMAL: conductivity matrix dimensions do not match thermal DOFs");
+
+    const DynamicVector heat_source = DynamicVector::Zero(active_temperatures);
+
+    // Validate solver and constraint-backend compatibility
+    if (constraint_method == ConstraintTransformer::Method::Lagrange && method == solver::INDIRECT) {
+        logging::error(false,
+            "STEADYSTATETHERMAL: LAGRANGE constraints require the DIRECT solver");
+    }
+
+    const auto direct_matrix_type =
+        constraint_method == ConstraintTransformer::Method::Lagrange
+            ? solver::DirectSolverMatrixType::General
+            : solver::DirectSolverMatrixType::SPD;
+
+    // Construct the affine representation of prescribed absolute temperatures
+    auto transformer = Timer::measure(
+        [&]() {
+            ConstraintTransformer::Options options;
+            options.method = constraint_method;
+            return std::make_unique<ConstraintTransformer>(
+                equations,
+                thermal_dof_ids,
+                active_temperatures,
+                options
+            );
+        },
+        "building thermal constraint transformer"
+    );
+    logging::error(transformer->feasible(),
+        "STEADYSTATETHERMAL: prescribed temperatures are inconsistent");
+
+    // Assemble the solver system including affine Dirichlet contributions
+    auto system_matrix = Timer::measure(
+        [&]() { return transformer->assemble_system_matrix(conductivity); },
+        "assembling constrained thermal matrix"
+    );
+    auto system_rhs = Timer::measure(
+        [&]() { return transformer->assemble_system_rhs(conductivity, heat_source); },
+        "assembling constrained thermal RHS"
+    );
+
+    // Reject invalid element or transformation results before entering a solver
+    bool matrix_finite = true;
+    for (int column = 0; column < system_matrix.outerSize() && matrix_finite; ++column) {
+        for (SparseMatrix::InnerIterator value(system_matrix, column); value; ++value) {
+            if (!std::isfinite(value.value())) {
+                matrix_finite = false;
+                break;
+            }
+        }
+    }
+    logging::error(matrix_finite,
+        "STEADYSTATETHERMAL: constrained conductivity matrix contains NaN or Inf");
+    logging::error(system_rhs.allFinite(),
+        "STEADYSTATETHERMAL: constrained right-hand side contains NaN or Inf");
+
+    // Solve the reduced or augmented system. A fully prescribed reduced system
+    // has no remaining algebraic unknowns and therefore needs no solver call.
+    auto solution = Timer::measure(
+        [&]() {
+            if (system_matrix.rows() == 0) {
+                return DynamicVector(0);
+            }
+            return solve(device, method, system_matrix, system_rhs, direct_matrix_type);
+        },
+        "solving steady-state thermal system"
+    );
+
+    // Recover the complete active temperature vector from affine coordinates
+    const DynamicVector active_temperature = transformer->recover_displacement(solution);
+    logging::error(active_temperature.size() == active_temperatures,
+        "STEADYSTATETHERMAL: recovered temperature vector has the wrong size");
+    logging::error(active_temperature.allFinite(),
+        "STEADYSTATETHERMAL: recovered temperature contains NaN or Inf");
+
+    // Expand active values into an explicit scalar nodal result field
+    model::Field temperature{
+        "TEMPERATURE",
+        model::FieldDomain::NODE,
+        model->_data->field_rows(model::FieldDomain::NODE),
+        1
+    };
+    temperature.set_zero();
+    for (Index node = 0; node < temperature.rows; ++node) {
+        const int thermal_dof = thermal_dof_ids(node, 0);
+        if (thermal_dof >= 0) {
+            temperature(node, 0) = active_temperature(thermal_dof);
+        }
+    }
+
+    // Recover conductive heat flux from the converged nodal temperatures
+    auto heat_flux = Timer::measure(
+        [&]() { return model->compute_heat_flux(temperature); },
+        "computing conductive heat flux"
+    );
+
+    // Write one stationary result frame in native and supported FRD formats
+    Timer::measure(
+        [&]() {
+            writer->add_loadcase(id, io::writer::WriterStepType::Static);
+            writer->write_field(temperature, "TEMPERATURE", model->_data.get());
+            writer->write_field(heat_flux  , "HEAT_FLUX" , model->_data.get());
+        },
+        "writing thermal result fields"
+    );
+
+    // Verify the recovered solution against the transformed thermal system
+    transformer->post_check_static(conductivity, heat_source, solution);
+}
+
+} // namespace fem::loadcase

--- a/src/loadcase/steady_state_thermal.cpp
+++ b/src/loadcase/steady_state_thermal.cpp
@@ -2,27 +2,16 @@
  * @file steady_state_thermal.cpp
  * @brief Implements linear steady-state heat-conduction analysis.
  *
- * The implementation enumerates one temperature unknown per thermally active
- * node, assembles the global conductivity matrix, imposes prescribed absolute
- * temperatures through the common constraint transformer and solves the zero-
- * source stationary balance. The recovered temperature drives element-level
- * Fourier heat-flux evaluation before both result fields are written.
- *
- * Thermal loads and capacity terms are deliberately absent. They belong to
- * future source/flux/convection conditions and transient thermal analysis.
- *
- * @see SteadyStateThermal
- * @see model::Model::build_conductivity_matrix
- * @see model::Model::compute_heat_flux
- *
  * @author Finn Eggers
- * @date 29.08.2026
+ * @date 30.08.2026
  */
 
 #include "steady_state_thermal.h"
 
+#include "../bc/neumann/thermal_load.h"
 #include "../core/logging.h"
 #include "../core/timer.h"
+#include "../model/element/element_thermal.h"
 #include "../model/model.h"
 
 #include <cmath>
@@ -32,26 +21,71 @@ namespace fem::loadcase {
 
 using constraint::ConstraintTransformer;
 
+namespace {
+
 /**
- * Solves the constrained stationary heat equation and writes thermal results.
+ * Projects element integration-point heat flux to a writer-compatible nodal field.
  *
- * The analysis performs the following phases:
- *
- * - assign compiled solid sections and enumerate scalar thermal unknowns,
- * - collect only `bc::Temperature` entries from the selected support collectors,
- * - assemble the conductivity operator and its zero heat-source right-hand side,
- * - transform and solve the affine constrained system,
- * - recover a one-component nodal temperature field,
- * - evaluate integration-point heat flux through Fourier's law,
- * - write `TEMPERATURE` and `HEAT_FLUX` as one static result frame.
- *
- * A missing temperature constraint leaves the zero-source conductivity problem
- * singular and is rejected explicitly. Additional disconnected components still
- * require one prescribed temperature each; the selected sparse solver diagnoses
- * any remaining singularity.
+ * The current thermal element interface recovers HFL at integration points. For
+ * visualization and FRD output, one mean flux vector is first assigned to every
+ * node of the contributing element. The established element-nodal averaging
+ * routine then combines connected-element contributions at each global node.
  */
+model::Field project_heat_flux_to_nodes(model::ModelData& data,
+                                        const model::Field& integration_flux) {
+    logging::error(integration_flux.domain == model::FieldDomain::ELEMENT_IP,
+        "HFL projection requires an ELEMENT_IP source field");
+    logging::error(integration_flux.components >= 3,
+        "HFL projection requires three heat-flux components");
+
+    const Index element_count = static_cast<Index>(data.elements.size());
+    model::Field element_flux{
+        "HFL_ELEMENT_NODAL",
+        model::FieldDomain::ELEMENT_NODAL,
+        data.field_rows(model::FieldDomain::ELEMENT_NODAL),
+        3
+    };
+    model::Field element_weights{
+        "HFL_ELEMENT_WEIGHTS",
+        model::FieldDomain::ELEMENT,
+        element_count,
+        1
+    };
+    element_flux.set_zero();
+    element_weights.set_zero();
+
+    for (const auto& element : data.elements) {
+        if (!element || !element->as<model::ThermalElement>()) continue;
+
+        const Index ip_count = element->num_ip();
+        if (ip_count == 0) continue;
+
+        Vec3 mean_flux = Vec3::Zero();
+        for (Index ip = 0; ip < ip_count; ++ip) {
+            const Index row = element->ip_index(ip);
+            for (Dim component = 0; component < 3; ++component) {
+                mean_flux(component) += integration_flux(row, component);
+            }
+        }
+        mean_flux /= static_cast<Precision>(ip_count);
+
+        for (Index local_node = 0; local_node < element->n_nodes(); ++local_node) {
+            const Index row = static_cast<Index>(element->elem_nodal_offset) + local_node;
+            for (Dim component = 0; component < 3; ++component) {
+                element_flux(row, component) = mean_flux(component);
+            }
+        }
+        element_weights(static_cast<Index>(element->elem_id), 0) = Precision(1);
+    }
+
+    auto nodal_flux = data.element_nodal_to_nodal(element_flux, element_weights, "HFL");
+    nodal_flux.check_finite("Nodal heat flux");
+    return nodal_flux;
+}
+
+} // namespace
+
 void SteadyStateThermal::run() {
-    // Print the analysis header and validate parser-assigned dependencies
     logging::info(true, "");
     logging::info(true, "");
     logging::info(true, "===============================================================================================");
@@ -64,10 +98,8 @@ void SteadyStateThermal::run() {
     logging::error(writer != nullptr,
         "STEADYSTATETHERMAL: result writer is not initialized");
 
-    // Bind material-bearing sections before thermal element evaluation
     model->assign_sections();
 
-    // Enumerate one active temperature unknown per thermal element node
     auto thermal_dof_ids = Timer::measure(
         [&]() { return model->build_thermal_index_matrix(); },
         "generating thermal DOF index matrix"
@@ -79,7 +111,6 @@ void SteadyStateThermal::run() {
         "STEADYSTATETHERMAL: model contains no thermally active element nodes");
     const Index active_temperatures = static_cast<Index>(max_thermal_dof + 1);
 
-    // Collect absolute temperature constraints from common support collectors
     auto groups = Timer::measure(
         [&]() { return model->collect_temperature_constraints(supps); },
         "collecting prescribed temperatures"
@@ -89,7 +120,7 @@ void SteadyStateThermal::run() {
     logging::error(!equations.empty(),
         "STEADYSTATETHERMAL: at least one prescribed temperature is required");
 
-    // Assemble the symmetric conduction operator and the zero source vector
+    // Conductive element contribution.
     auto conductivity = Timer::measure(
         [&]() { return model->build_conductivity_matrix(thermal_dof_ids); },
         "constructing thermal conductivity matrix K_T"
@@ -98,9 +129,37 @@ void SteadyStateThermal::run() {
                 && conductivity.cols() == active_temperatures,
         "STEADYSTATETHERMAL: conductivity matrix dimensions do not match thermal DOFs");
 
-    const DynamicVector heat_source = DynamicVector::Zero(active_temperatures);
+    // Natural thermal boundary conditions. Prescribed heat flux contributes only
+    // to f_T; convection contributes both K_h and f_h.
+    DynamicVector heat_source = DynamicVector::Zero(active_temperatures);
+    TripletList boundary_terms;
 
-    // Validate solver and constraint-backend compatibility
+    Timer::measure(
+        [&]() {
+            for (const auto& name : loads) {
+                logging::error(model->_data->thermal_load_cols.has(name),
+                    "STEADYSTATETHERMAL: thermal load collector ", name, " does not exist");
+                const auto collector = model->_data->thermal_load_cols.get(name);
+                logging::error(collector != nullptr,
+                    "STEADYSTATETHERMAL: thermal load collector ", name, " is not initialized");
+
+                for (const auto& load : collector->entries()) {
+                    if (load) {
+                        load->apply(*model->_data, thermal_dof_ids, boundary_terms, heat_source);
+                    }
+                }
+            }
+        },
+        "assembling thermal Neumann conditions"
+    );
+
+    if (!boundary_terms.empty()) {
+        SparseMatrix boundary_matrix(active_temperatures, active_temperatures);
+        boundary_matrix.setFromTriplets(boundary_terms.begin(), boundary_terms.end());
+        conductivity += boundary_matrix;
+        conductivity.makeCompressed();
+    }
+
     if (constraint_method == ConstraintTransformer::Method::Lagrange && method == solver::INDIRECT) {
         logging::error(false,
             "STEADYSTATETHERMAL: LAGRANGE constraints require the DIRECT solver");
@@ -111,7 +170,6 @@ void SteadyStateThermal::run() {
             ? solver::DirectSolverMatrixType::General
             : solver::DirectSolverMatrixType::SPD;
 
-    // Construct the affine representation of prescribed absolute temperatures
     auto transformer = Timer::measure(
         [&]() {
             ConstraintTransformer::Options options;
@@ -128,7 +186,6 @@ void SteadyStateThermal::run() {
     logging::error(transformer->feasible(),
         "STEADYSTATETHERMAL: prescribed temperatures are inconsistent");
 
-    // Assemble the solver system including affine Dirichlet contributions
     auto system_matrix = Timer::measure(
         [&]() { return transformer->assemble_system_matrix(conductivity); },
         "assembling constrained thermal matrix"
@@ -138,7 +195,6 @@ void SteadyStateThermal::run() {
         "assembling constrained thermal RHS"
     );
 
-    // Reject invalid element or transformation results before entering a solver
     bool matrix_finite = true;
     for (int column = 0; column < system_matrix.outerSize() && matrix_finite; ++column) {
         for (SparseMatrix::InnerIterator value(system_matrix, column); value; ++value) {
@@ -153,8 +209,6 @@ void SteadyStateThermal::run() {
     logging::error(system_rhs.allFinite(),
         "STEADYSTATETHERMAL: constrained right-hand side contains NaN or Inf");
 
-    // Solve the reduced or augmented system. A fully prescribed reduced system
-    // has no remaining algebraic unknowns and therefore needs no solver call.
     auto solution = Timer::measure(
         [&]() {
             if (system_matrix.rows() == 0) {
@@ -165,14 +219,12 @@ void SteadyStateThermal::run() {
         "solving steady-state thermal system"
     );
 
-    // Recover the complete active temperature vector from affine coordinates
     const DynamicVector active_temperature = transformer->recover_displacement(solution);
     logging::error(active_temperature.size() == active_temperatures,
         "STEADYSTATETHERMAL: recovered temperature vector has the wrong size");
     logging::error(active_temperature.allFinite(),
         "STEADYSTATETHERMAL: recovered temperature contains NaN or Inf");
 
-    // Expand active values into an explicit scalar nodal result field
     model::Field temperature{
         "TEMPERATURE",
         model::FieldDomain::NODE,
@@ -187,23 +239,47 @@ void SteadyStateThermal::run() {
         }
     }
 
-    // Recover conductive heat flux from the converged nodal temperatures
-    auto heat_flux = Timer::measure(
+    // Element HFL is currently recovered at integration points. Convert it to a
+    // NODE field before handing it to writers, which also addresses FRD output.
+    auto integration_flux = Timer::measure(
         [&]() { return model->compute_heat_flux(temperature); },
         "computing conductive heat flux"
     );
+    auto heat_flux = Timer::measure(
+        [&]() { return project_heat_flux_to_nodes(*model->_data, integration_flux); },
+        "projecting heat flux to nodes"
+    );
 
-    // Write one stationary result frame in native and supported FRD formats
+    // Reaction heat flow is the full thermal residual. Free nodes are zero up to
+    // solver tolerance; prescribed-temperature nodes retain the required power.
+    const DynamicVector active_reaction = conductivity * active_temperature - heat_source;
+    logging::error(active_reaction.allFinite(),
+        "STEADYSTATETHERMAL: recovered reaction heat flux contains NaN or Inf");
+
+    model::Field reaction{
+        "RFL",
+        model::FieldDomain::NODE,
+        model->_data->field_rows(model::FieldDomain::NODE),
+        1
+    };
+    reaction.set_zero();
+    for (Index node = 0; node < reaction.rows; ++node) {
+        const int thermal_dof = thermal_dof_ids(node, 0);
+        if (thermal_dof >= 0) {
+            reaction(node, 0) = active_reaction(thermal_dof);
+        }
+    }
+
     Timer::measure(
         [&]() {
             writer->add_loadcase(id, io::writer::WriterStepType::Static);
             writer->write_field(temperature, "TEMPERATURE", model->_data.get());
-            writer->write_field(heat_flux  , "HEAT_FLUX" , model->_data.get());
+            writer->write_field(heat_flux  , "HFL"        , model->_data.get());
+            writer->write_field(reaction   , "RFL"        , model->_data.get());
         },
         "writing thermal result fields"
     );
 
-    // Verify the recovered solution against the transformed thermal system
     transformer->post_check_static(conductivity, heat_source, solution);
 }
 

--- a/src/loadcase/steady_state_thermal.h
+++ b/src/loadcase/steady_state_thermal.h
@@ -1,0 +1,65 @@
+/**
+ * @file steady_state_thermal.h
+ * @brief Declares the linear steady-state thermal load case.
+ *
+ * The load case solves scalar heat conduction in thermally capable solid
+ * elements with constant material conductivity. Prescribed temperatures are
+ * selected from the model's common support collectors; heat sources, prescribed
+ * fluxes and convection are intentionally outside the initial formulation.
+ *
+ * The resulting system is `K_T T = 0` subject to affine temperature constraints.
+ * Conductivity assembly and heat-flux recovery remain responsibilities of
+ * `model::Model` and `model::ThermalElement`.
+ *
+ * @see SteadyStateThermal
+ * @see model::ThermalElement
+ * @see bc::Temperature
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
+
+#pragma once
+
+#include "loadcase.h"
+
+#include "../constraints/transformer/constraint_transformer.h"
+#include "../solve/sparse/solve_sparse.h"
+
+#include <string>
+#include <vector>
+
+namespace fem::loadcase {
+
+/**
+ * @brief Solves linear stationary heat conduction with prescribed temperatures.
+ *
+ * Every node connected to a `model::ThermalElement` owns one scalar temperature
+ * unknown. Element conductivity matrices form the symmetric global operator,
+ * while `bc::Temperature` objects selected from the named support collectors
+ * impose absolute nodal values through the common constraint transformer.
+ *
+ * No thermal load vector is assembled in this first formulation. A non-trivial
+ * temperature field is driven entirely by differing prescribed boundary values.
+ * Every disconnected thermal component must therefore contain at least one
+ * temperature support to remove its constant-temperature null mode.
+ *
+ * The converged scalar nodal temperature and global integration-point heat flux
+ * are written as `TEMPERATURE` and `HEAT_FLUX` result fields.
+ */
+struct SteadyStateThermal : LoadCase {
+    // Common support collectors from which temperature definitions are selected
+    std::vector<std::string> supps{};
+
+    // Linear solver and affine constraint backends
+    solver::SolverDevice device = solver::CPU;
+    solver::SolverMethod method = solver::DIRECT;
+    constraint::ConstraintTransformer::Method constraint_method =
+        constraint::ConstraintTransformer::Method::NullSpace;
+
+    // Analysis identity and execution
+    std::string type_name() const override { return "STEADYSTATETHERMAL"; }
+    void run() override;
+};
+
+} // namespace fem::loadcase

--- a/src/loadcase/steady_state_thermal.h
+++ b/src/loadcase/steady_state_thermal.h
@@ -2,21 +2,8 @@
  * @file steady_state_thermal.h
  * @brief Declares the linear steady-state thermal load case.
  *
- * The load case solves scalar heat conduction in thermally capable solid
- * elements with constant material conductivity. Prescribed temperatures are
- * selected from the model's common support collectors; heat sources, prescribed
- * fluxes and convection are intentionally outside the initial formulation.
- *
- * The resulting system is `K_T T = 0` subject to affine temperature constraints.
- * Conductivity assembly and heat-flux recovery remain responsibilities of
- * `model::Model` and `model::ThermalElement`.
- *
- * @see SteadyStateThermal
- * @see model::ThermalElement
- * @see bc::Temperature
- *
  * @author Finn Eggers
- * @date 29.08.2026
+ * @date 30.08.2026
  */
 
 #pragma once
@@ -32,32 +19,18 @@
 namespace fem::loadcase {
 
 /**
- * @brief Solves linear stationary heat conduction with prescribed temperatures.
- *
- * Every node connected to a `model::ThermalElement` owns one scalar temperature
- * unknown. Element conductivity matrices form the symmetric global operator,
- * while `bc::Temperature` objects selected from the named support collectors
- * impose absolute nodal values through the common constraint transformer.
- *
- * No thermal load vector is assembled in this first formulation. A non-trivial
- * temperature field is driven entirely by differing prescribed boundary values.
- * Every disconnected thermal component must therefore contain at least one
- * temperature support to remove its constant-temperature null mode.
- *
- * The converged scalar nodal temperature and global integration-point heat flux
- * are written as `TEMPERATURE` and `HEAT_FLUX` result fields.
+ * @brief Solves stationary heat conduction with Dirichlet and Neumann data.
  */
 struct SteadyStateThermal : LoadCase {
-    // Common support collectors from which temperature definitions are selected
+    // Dirichlet support collectors and thermal Neumann load collectors.
     std::vector<std::string> supps{};
+    std::vector<std::string> loads{};
 
-    // Linear solver and affine constraint backends
     solver::SolverDevice device = solver::CPU;
     solver::SolverMethod method = solver::DIRECT;
     constraint::ConstraintTransformer::Method constraint_method =
         constraint::ConstraintTransformer::Method::NullSpace;
 
-    // Analysis identity and execution
     std::string type_name() const override { return "STEADYSTATETHERMAL"; }
     void run() override;
 };

--- a/src/material/material.cpp
+++ b/src/material/material.cpp
@@ -52,6 +52,7 @@ void Material::info() const {
     logging::info(true, "Material: ", name);
     logging::info(true, "   Elasticity          : ", (has_elasticity() ? "YES" : "NO"));
     logging::info(true, "   Thermal Capacity    : ", (has_thermal_specific_heat() ? std::to_string(m_thermal_specific_heat) : "NO"));
+    logging::info(true, "   Thermal Conductivity: ", (has_thermal_conductivity() ? std::to_string(m_thermal_conductivity) : "NO"));
     logging::info(true, "   Thermal Expansion   : ", (has_thermal_expansion() ? std::to_string(m_thermal_expansion) : "NO"));
     logging::info(true, "   Density             : ", (has_density() ? std::to_string(m_density) : "NO"));
 }

--- a/src/model/beam/b31.h
+++ b/src/model/beam/b31.h
@@ -1,0 +1,101 @@
+/**
+ * @file b31.h
+ * @brief Declares a two-node beam with axial heat-conduction capability.
+ */
+
+#pragma once
+
+#include "b33.h"
+#include "../element/element_thermal.h"
+
+namespace fem::model {
+
+/**
+ * @brief FEMaster B31 compatibility element using the existing B33 mechanics.
+ *
+ * The thermal formulation assumes temperature is uniform over the beam cross
+ * section and conducts only along the reference centerline.
+ */
+struct B31 : B33, ThermalElement {
+    B31(ID elem_id, std::array<ID, 2> node_ids)
+        : B33(elem_id, node_ids) {}
+
+    ElementPtr copy() const override {
+        return std::make_shared<B31>(elem_id, node_ids);
+    }
+
+    std::string type_name() const override { return "B31"; }
+
+    Precision thermal_length() const {
+        logging::error(_model_data != nullptr && _model_data->positions_reference != nullptr,
+            "B31: reference positions are not initialized for element ", elem_id);
+        const Vec3 x0 = _model_data->positions_reference->row_vec3(static_cast<Index>(node_ids[0]));
+        const Vec3 x1 = _model_data->positions_reference->row_vec3(static_cast<Index>(node_ids[1]));
+        const Precision length = (x1 - x0).norm();
+        logging::error(length > Precision(0),
+            "B31: zero reference length for element ", elem_id);
+        return length;
+    }
+
+    Vec3 thermal_direction() const {
+        const Vec3 x0 = _model_data->positions_reference->row_vec3(static_cast<Index>(node_ids[0]));
+        const Vec3 x1 = _model_data->positions_reference->row_vec3(static_cast<Index>(node_ids[1]));
+        return (x1 - x0) / thermal_length();
+    }
+
+    MapMatrix conductivity(Precision* buffer) override {
+        auto material = get_material();
+        logging::error(material->has_thermal_conductivity(),
+            "B31: material has no thermal conductivity for element ", elem_id);
+
+        const Precision scale = material->get_thermal_conductivity()
+                              * get_profile()->area_ / thermal_length();
+
+        MapMatrix matrix(buffer, 2, 2);
+        matrix << scale, -scale,
+                 -scale,  scale;
+        return matrix;
+    }
+
+    MapMatrix capacity(Precision* buffer) override {
+        auto material = get_material();
+        logging::error(material->has_density(),
+            "B31: material has no density for element ", elem_id);
+        logging::error(material->has_thermal_specific_heat(),
+            "B31: material has no specific heat for element ", elem_id);
+
+        const Precision scale = material->get_density()
+                              * material->get_thermal_specific_heat()
+                              * get_profile()->area_ * thermal_length() / Precision(6);
+
+        MapMatrix matrix(buffer, 2, 2);
+        matrix << Precision(2) * scale, scale,
+                  scale, Precision(2) * scale;
+        return matrix;
+    }
+
+    void compute_heat_flux(Field& heat_flux, const Field& temperature) override {
+        logging::error(heat_flux.domain == FieldDomain::ELEMENT_IP,
+            "B31: heat flux output must use ELEMENT_IP domain");
+        logging::error(heat_flux.components >= 3,
+            "B31: heat flux output requires three components");
+        logging::error(temperature.domain == FieldDomain::NODE && temperature.components == 1,
+            "B31: temperature must be a scalar NODE field");
+
+        auto material = get_material();
+        logging::error(material->has_thermal_conductivity(),
+            "B31: material has no thermal conductivity for element ", elem_id);
+
+        const Precision t0 = temperature(static_cast<Index>(node_ids[0]), 0);
+        const Precision t1 = temperature(static_cast<Index>(node_ids[1]), 0);
+        const Vec3 flux = -material->get_thermal_conductivity()
+                        * (t1 - t0) / thermal_length() * thermal_direction();
+
+        const Index row = ip_index(0);
+        for (Dim component = 0; component < 3; ++component) {
+            heat_flux(row, component) = flux(component);
+        }
+    }
+};
+
+} // namespace fem::model

--- a/src/model/element/element_structural.h
+++ b/src/model/element/element_structural.h
@@ -100,11 +100,11 @@ struct StructuralElement : ElementInterface {
         return false;
     }
     virtual bool compute_shell_section_forces(Field& section_forces,
-                                              Field& contribution_count,
-                                              const Field& displacement) {
+                                              const Field& displacement,
+                                              int offset) {
         (void) section_forces;
-        (void) contribution_count;
         (void) displacement;
+        (void) offset;
         return false;
     }
 };

--- a/src/model/element/element_thermal.cpp
+++ b/src/model/element/element_thermal.cpp
@@ -1,5 +1,15 @@
-//
-// Created by Luecx on 29.08.2026.
-//
+/**
+ * @file element_thermal.cpp
+ * @brief Provides the translation unit for the thermal element interface.
+ *
+ * Thermal operations are purely virtual and implemented by concrete element
+ * formulations. This translation unit keeps the interface available to build
+ * systems that enumerate source files independently of header usage.
+ *
+ * @see ThermalElement
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
 
 #include "element_thermal.h"

--- a/src/model/element/element_thermal.h
+++ b/src/model/element/element_thermal.h
@@ -1,25 +1,55 @@
 
+/**
+ * @file element_thermal.h
+ * @brief Declares the thermal finite-element capability interface.
+ *
+ * Thermal behavior is modeled as an orthogonal element capability alongside
+ * structural mechanics. Concrete solid elements may implement both interfaces;
+ * model assembly cross-casts the common `ElementInterface` pointer to
+ * `ThermalElement` when conductivity, capacity or heat-flux operations are
+ * requested.
+ *
+ * Steady-state analysis consumes only conductivity and heat flux. Capacity is
+ * retained for a future transient thermal load case.
+ *
+ * @see ThermalElement
+ * @see SolidElement
+ * @see loadcase::SteadyStateThermal
+ *
+ * @author Finn Eggers
+ * @date 29.08.2026
+ */
+
 #pragma once
 
 #include "element.h"
-#include <functional>
 
-namespace fem {
-namespace model {
+namespace fem::model {
 
+/**
+ * @brief Provides scalar heat-transfer operations for a finite element.
+ *
+ * A thermal element associates one scalar temperature unknown with every
+ * connectivity node. `conductivity()` and `capacity()` return element matrices
+ * in that nodal ordering using caller-owned storage. `compute_heat_flux()`
+ * differentiates a converged global nodal temperature field and writes global
+ * Cartesian flux components to the element's compiled integration-point range.
+ *
+ * Implementations must not own the supplied matrix buffer or result fields.
+ * Their topology, section, material and compiled offsets remain owned by the
+ * accompanying `ElementInterface` subobject of the concrete element.
+ */
 struct ThermalElement {
+    // Polymorphic destruction through the thermal capability interface
     virtual ~ThermalElement() = default;
 
-    // conductivity and capacity matrix for head transfer problems
+    // Scalar nodal conductivity and capacity matrices in element connectivity
+    // order. The returned maps reference the caller-owned buffer.
     virtual MapMatrix conductivity(Precision* buffer) = 0;
     virtual MapMatrix capacity    (Precision* buffer) = 0;
 
-    virtual void compute_heat_flux(
-        Field&       heat_flux,
-        const Field& temperature
-    ) = 0;
+    // Recover global Cartesian heat flux into the element's compiled IP rows
+    virtual void compute_heat_flux(Field& heat_flux, const Field& temperature) = 0;
 };
 
-
-} // namespace model
-} // namespace fem
+} // namespace fem::model

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -351,16 +351,19 @@ void Model::add_amplitude(bc::Amplitude::Ptr amplitude) {
  *
  * Supports resolve compiled assembly regions when constraint equations are
  * collected. Registration therefore requires a compiled model and an active
- * collector. The support value is moved into that collector.
+ * collector. Mechanical and thermal support implementations share the same
+ * polymorphic ownership path.
  *
- * @param support Support definition to register.
+ * @param support Prescribed boundary condition to register.
  */
-void Model::add_support(bc::Support support) {
+void Model::add_support(bc::SupportInterface::Ptr support) {
     // Validate the compiled model state and collector target
     logging::error(_data != nullptr && _data->compiled,
         "Model: supports require a compiled model");
     logging::error(_data->supp_cols.has_any() && _data->supp_cols.get() != nullptr,
         "Model: no support collector is active");
+    logging::error(support != nullptr,
+        "Model: cannot add a null support");
 
     // Transfer the support into the selected collector
     _data->supp_cols.get()->add(std::move(support));

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "../bc/amplitude.h"
+#include "../bc/support_interface.h"
 #include "../constraints/constraint_groups.h"
 #include "../core/types_cls.h"
 #include "../cos/coordinate_system.h"
@@ -154,7 +155,7 @@ struct Model {
     // helper; callers append their concrete type directly to ModelData.
     void add_load     (bc::Load::Ptr load);
     void add_amplitude(bc::Amplitude::Ptr amplitude);
-    void add_support  (bc::Support support);
+    void add_support  (bc::SupportInterface::Ptr support);
 
     // Compiled element preparation and analysis lifecycle. Section assignment
     // binds compiled elements to their section definitions, and shell-normal
@@ -173,21 +174,26 @@ struct Model {
     void initialize_material_state(Field& state) const;
 
     // Global system construction. These operations enumerate active DOFs,
-    // collect prescribed loads and constraints, and assemble structural tangent,
-    // geometric, mass and internal-force contributions in global coordinates.
-    // Optional stiffness-scaling fields act per element.
+    // collect prescribed loads and constraints, and assemble structural or
+    // thermal operators in global coordinates. The thermal mapping uses only
+    // local component zero for its scalar temperature unknown. Optional
+    // structural stiffness-scaling fields act per element.
     SystemDofIds build_unconstrained_index_matrix();
+    SystemDofIds build_thermal_index_matrix();
     Field build_load_matrix(
         std::vector<std::string> load_sets = {},
         Precision time = 0);
     constraint::ConstraintGroups collect_constraints(
         SystemDofIds& system_dof_ids,
         const std::vector<std::string>& supp_sets = {});
+    constraint::ConstraintGroups collect_temperature_constraints(
+        const std::vector<std::string>& supp_sets = {});
     std::vector<std::pair<bc::Amplitude::Ptr, Field>> build_load_basis(
         std::vector<std::string> load_sets = {});
     SparseMatrix build_stiffness_matrix(
         SystemDofIds& indices,
         const Field* stiffness_scalar = nullptr);
+    SparseMatrix build_conductivity_matrix(SystemDofIds& indices);
     SparseMatrix build_tangent_stiffness_matrix(
         SystemDofIds& indices,
         NodeData& nodal_forces,
@@ -206,7 +212,7 @@ struct Model {
     // Result recovery from compiled structural elements. Returned fields use the
     // domain appropriate to each quantity, including integration-point stress,
     // element-nodal stress/strain, shell resultants and element-level compliance,
-    // volume, section-force and shear-flow measures.
+    // volume, section-force, shear-flow and thermal heat-flux measures.
     Field compute_stress_state(Field& displacement, bool use_green_lagrange_nl = false);
     std::tuple<Field, Field> compute_stress_nodal(Field& displacement, bool use_green_lagrange_nl = false);
     std::tuple<Field, Field> compute_stress_top_bot(Field& displacement, bool use_green_lagrange_nl = false);
@@ -216,6 +222,7 @@ struct Model {
     Field compute_volumes();
     Field compute_section_forces(Field& displacement);
     Field compute_shear_flow(Field& displacement);
+    Field compute_heat_flux(const Field& temperature);
 
     // Human-readable diagnostics. The overview reports semantic topology,
     // compiled assembly data and associated definitions through the hierarchical

--- a/src/model/model_build.cpp
+++ b/src/model/model_build.cpp
@@ -4,10 +4,9 @@
  *
  * The routines operate on the dense assembly created by `Model::compile()`.
  * They bind sections to compiled elements, construct shared shell reference
- * normals, enumerate active generalized DOFs, assemble loads and constraint
- * equations, and combine regular elements, post-compile point elements, contact
- * and generic feature contributions into global sparse operators and nodal
- * internal-force fields.
+ * normals, enumerate structural or scalar thermal DOFs, assemble loads and
+ * constraint equations, and combine element contributions into global sparse
+ * structural or conductivity operators and nodal internal-force fields.
  *
  * FEMaster `POINTMASS` commands create auxiliary `PointElement` objects after
  * compilation because they target compiled NSETs. Those point elements are kept
@@ -15,8 +14,8 @@
  * DOF, stiffness and mass operators as regular structural elements.
  *
  * Element-local matrix evaluation remains the responsibility of each structural
- * formulation. `mattools::assemble_matrix()` owns local-to-global DOF mapping,
- * sparse triplet accumulation and parallel reduction.
+ * or thermal formulation. `mattools::assemble_matrix()` owns local-to-global
+ * DOF mapping, sparse triplet accumulation and parallel reduction.
  *
  * @see Model
  * @see Model::compile
@@ -26,9 +25,11 @@
  * @date 25.08.2026
  */
 
+#include "../bc/thermal_temp.h"
 #include "../mattools/assemble.h"
 #include "../mattools/numerate_dofs.h"
 #include "element/element_structural.h"
+#include "element/element_thermal.h"
 #include "model.h"
 #include "solid/element_solid.h"
 
@@ -290,6 +291,39 @@ SystemDofIds Model::build_unconstrained_index_matrix() {
 }
 
 /**
+ * Enumerates the scalar nodal temperature unknowns required by thermal elements.
+ *
+ * FEMaster's common system mapping retains six columns for compatibility with
+ * sparse assembly and constraint transformation. The thermal system activates
+ * only local component zero at nodes connected to a `ThermalElement`; every
+ * other component and node remains inactive. Temperature equations using local
+ * degree of freedom zero therefore map into one compact contiguous system.
+ *
+ * @return Node-by-six mapping with active temperature indices only in column zero.
+ */
+SystemDofIds Model::build_thermal_index_matrix() {
+    // Validate the compiled nodal domain before constructing the thermal mask
+    logging::error(_data->positions != nullptr,
+        "Model: POSITION field is not initialized");
+
+    SystemDofs mask{_data->positions->rows, 6};
+    mask.fill(false);
+
+    // Activate one scalar temperature unknown at every thermal element node
+    for (const auto& element : _data->elements) {
+        if (element == nullptr || element->as<ThermalElement>() == nullptr) continue;
+
+        for (ID local_node = 0; local_node < element->n_nodes(); ++local_node) {
+            const ID node_id = element->nodes()[local_node];
+            mask(node_id, 0) = true;
+        }
+    }
+
+    // Convert the scalar mask into contiguous global thermal identifiers
+    return mattools::numerate_dofs(mask);
+}
+
+/**
  * Assembles selected load collectors into one global nodal load field.
  *
  * Each named collector evaluates its loads at `time`, including any attached
@@ -368,8 +402,10 @@ Model::build_load_basis(std::vector<std::string> load_sets) {
  *
  * When no support collector names are supplied, the aggregate support collection
  * is used when available; otherwise only the named collectors participate.
- * Connector, coupling, tie and rigid-body-mode objects generate their equations
- * in model order. Manually stored equations are copied into the fallback group.
+ * Heterogeneous collectors contribute only their structural `bc::Support`
+ * entries to this mechanical system. Connector, coupling, tie and rigid-body-
+ * mode objects generate their equations in model order. Manually stored
+ * equations are copied into the fallback group.
  *
  * @param system_dof_ids Active global DOF identifiers used by constraint builders.
  * @param supp_sets Optional names of support collectors to include.
@@ -384,7 +420,7 @@ constraint::ConstraintGroups Model::collect_constraints(
     Index support_idx = 0;
     if (supp_sets.empty() && _data->supp_cols.has_all()) {
         if (auto all = _data->supp_cols.all()) {
-            auto eqs = all->get_equations(*_data);
+            auto eqs = all->get_equations<bc::Support>(*_data);
             for (auto& eq : eqs) {
                 eq.source       = constraint::EquationSourceKind::Support;
                 eq.source_index = support_idx;
@@ -396,7 +432,7 @@ constraint::ConstraintGroups Model::collect_constraints(
 
     for (const auto& key : supp_sets) {
         if (auto data = _data->supp_cols.get(key)) {
-            auto eqs = data->get_equations(*_data);
+            auto eqs = data->get_equations<bc::Support>(*_data);
             for (auto& eq : eqs) {
                 eq.source       = constraint::EquationSourceKind::Support;
                 eq.source_index = support_idx;
@@ -465,6 +501,56 @@ constraint::ConstraintGroups Model::collect_constraints(
 }
 
 /**
+ * Collects prescribed temperatures from the selected common support collectors.
+ *
+ * Support collectors may contain both mechanical `bc::Support` objects and
+ * thermal `bc::Temperature` objects. This path selects only temperatures,
+ * preserves collector and entry order and annotates every generated equation as
+ * a support constraint. Structural connectors, couplings, ties, rigid-body
+ * modes and manual mechanical equations deliberately do not participate.
+ *
+ * When no collector names are supplied, the aggregate support collection is
+ * used if one exists. Every explicitly named collector must already be defined.
+ *
+ * @param supp_sets Names of common support collectors used by the thermal load case.
+ * @return Constraint groups containing prescribed-temperature equations only.
+ */
+constraint::ConstraintGroups Model::collect_temperature_constraints(
+    const std::vector<std::string>& supp_sets
+) {
+    constraint::ConstraintGroups groups{};
+
+    // Append one collector while retaining its source index for diagnostics
+    Index support_idx = 0;
+    auto append_collector = [&](const bc::SupportCollector::Ptr& collector) {
+        logging::error(collector != nullptr,
+            "Model: thermal support collector is not initialized");
+
+        auto equations = collector->get_equations<bc::Temperature>(*_data);
+        for (auto& equation : equations) {
+            equation.source       = constraint::EquationSourceKind::Support;
+            equation.source_index = support_idx;
+            groups.supports.push_back(std::move(equation));
+        }
+        ++support_idx;
+    };
+
+    // Use the aggregate collector only without an explicit selection
+    if (supp_sets.empty() && _data->supp_cols.has_all()) {
+        append_collector(_data->supp_cols.all());
+    }
+
+    // Resolve every explicitly selected common support collector
+    for (const std::string& key : supp_sets) {
+        logging::error(_data->supp_cols.has(key),
+            "Model: thermal support collector ", key, " is not defined");
+        append_collector(_data->supp_cols.get(key));
+    }
+
+    return groups;
+}
+
+/**
  * Assembles the linear global structural stiffness matrix.
  *
  * Regular compiled elements and post-compile native point elements both use the
@@ -519,6 +605,34 @@ SparseMatrix Model::build_stiffness_matrix(SystemDofIds& indices, const Field* s
     }
 
     return matrix;
+}
+
+/**
+ * Assembles the global steady-state thermal conductivity matrix.
+ *
+ * Every `ThermalElement` supplies one scalar nodal conductivity matrix evaluated
+ * in the reference configuration. The common sparse assembly maps its local
+ * node ordering through column zero of the thermal index matrix. Non-thermal
+ * elements return an empty local matrix and do not contribute.
+ *
+ * The common assembler selects its serial or OpenMP implementation from the
+ * configured worker count and owns the parallel reduction of element entries.
+ *
+ * @param indices Thermal system mapping with active identifiers in column zero.
+ * @return Symmetric global conductivity matrix over all active temperatures.
+ */
+SparseMatrix Model::build_conductivity_matrix(SystemDofIds& indices) {
+    // Evaluate thermal element matrices through the common sparse assembly path
+    auto conductivity = [](const ElementPtr& element, Precision* storage) {
+        if (auto thermal = element->as<ThermalElement>()) {
+            return thermal->conductivity(storage);
+        }
+
+        MapMatrix matrix{storage, 0, 0};
+        return matrix;
+    };
+
+    return mattools::assemble_matrix(_data->elements, indices, conductivity);
 }
 
 /**

--- a/src/model/model_compute.cpp
+++ b/src/model/model_compute.cpp
@@ -8,9 +8,10 @@
  * element-nodal quantities are recovered into global nodal fields through the
  * weighting operation provided by `ModelData`.
  *
- * Nodal stress recovery, shell-face recovery, beam section forces and shear
- * flow may evaluate elements with OpenMP. Eigen and MKL internal threading are
- * temporarily restricted during those loops to avoid nested oversubscription.
+ * Nodal stress recovery, shell-face recovery, shell resultants, beam section
+ * forces, shear flow and conductive heat flux may evaluate elements with
+ * OpenMP. Eigen and MKL internal threading are temporarily restricted during
+ * those loops to avoid nested oversubscription.
  *
  * @see Model
  * @see ModelData
@@ -22,6 +23,7 @@
 
 #include "../core/config.h"
 #include "element/element_structural.h"
+#include "element/element_thermal.h"
 #include "model.h"
 #include "shell/s8.h"
 
@@ -248,38 +250,76 @@ std::tuple<Field, Field> Model::compute_stress_top_bot(Field& displacement, bool
 /**
  * Recovers nodal shell force and moment resultants.
  *
- * Supporting elements accumulate their eight-component resultant convention and
- * one participation count at every connected global node. The model divides the
- * accumulated values by those counts to obtain an arithmetic nodal average;
- * nodes without shell contributions retain zero rows.
+ * Supporting elements write their eight-component resultant convention into
+ * disjoint compiled `ELEMENT_NODAL` ranges. Element evaluation may therefore
+ * run in parallel. A scalar element weight marks participating shells before
+ * the common element-nodal projection forms the arithmetic nodal average.
  *
  * @param displacement Global nodal displacement field used for recovery.
  * @return Averaged eight-component nodal shell-resultant field.
  */
 Field Model::compute_shell_resultants(Field& displacement) {
-    // Allocate nodal accumulators for resultants and contribution counts
-    const Index node_count = _data->field_rows(FieldDomain::NODE);
-    Field resultants{"SHELL_RESULTANTS", FieldDomain::NODE, node_count, 8};
-    Field count{"SHELL_RESULTANTS_COUNT", FieldDomain::NODE, node_count, 1};
-    resultants.set_zero();
-    count.set_zero();
+    // Validate and access the compiled element-nodal enumeration
+    logging::error(_data->element_nodal_offsets != nullptr,
+        "element nodal offset field has not been initialized");
 
-    // Accumulate formulation-specific shell resultants from structural elements
-    for (auto el : _data->elements) {
+    const auto& nodal_offsets = *_data->element_nodal_offsets;
+    const Index total_element_nodes = _data->field_rows(FieldDomain::ELEMENT_NODAL);
+    const Index element_count       = static_cast<Index>(_data->elements.size());
+
+    // Allocate disjoint element-nodal output and one participation weight per element
+    Field element_resultants{
+        "ELEMENT_NODAL_SHELL_RESULTANTS",
+        FieldDomain::ELEMENT_NODAL,
+        total_element_nodes,
+        8
+    };
+    Field element_weights{
+        "SHELL_RESULTANT_ELEMENT_WEIGHTS",
+        FieldDomain::ELEMENT,
+        element_count,
+        1
+    };
+    element_resultants.set_zero();
+    element_weights.set_zero();
+
+    // Prevent nested Eigen/MKL threading inside the element-parallel recovery loop
+    Eigen::setNbThreads(1);
+#ifdef USE_MKL
+    mkl_set_num_threads(1);
+#endif
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static, 1024) num_threads(global_config.max_threads) if(global_config.max_threads > 1)
+#endif
+    // Recover shell resultants into each element's disjoint nodal row range
+    for (Index elem_idx = 0; elem_idx < element_count; ++elem_idx) {
+        auto el = _data->elements[static_cast<std::size_t>(elem_idx)];
         if (!el) continue;
         if (auto sel = el->as<StructuralElement>()) {
-            sel->compute_shell_section_forces(resultants, count, displacement);
-        }
-    }
-
-    // Convert accumulated contributions into arithmetic nodal averages
-    for (Index i = 0; i < node_count; ++i) {
-        if (count(i, 0) != Precision(0)) {
-            for (Index j = 0; j < resultants.components; ++j) {
-                resultants(i, j) /= count(i, 0);
+            const Index offset = static_cast<Index>(nodal_offsets(static_cast<Index>(sel->elem_id), 0));
+            const bool participates = sel->compute_shell_section_forces(
+                element_resultants,
+                displacement,
+                static_cast<int>(offset)
+            );
+            if (participates) {
+                element_weights(static_cast<Index>(sel->elem_id), 0) = Precision(1);
             }
         }
     }
+
+    // Restore the configured linear-algebra thread counts after element recovery
+#ifdef USE_MKL
+    mkl_set_num_threads(global_config.max_threads);
+#endif
+    Eigen::setNbThreads(global_config.max_threads);
+
+    // Average participating element values onto global nodes
+    Field resultants = _data->element_nodal_to_nodal(
+        element_resultants,
+        element_weights,
+        "SHELL_RESULTANTS"
+    );
 
     // Validate the averaged result field before returning it
     resultants.check_finite("Shell resultants");
@@ -461,6 +501,65 @@ Field Model::compute_shear_flow(Field& displacement) {
 #endif
     Eigen::setNbThreads(global_config.max_threads);
     return shear_flow;
+}
+
+/**
+ * Recovers conductive heat flux at every thermal element integration point.
+ *
+ * Thermal elements differentiate the converged scalar nodal temperature in the
+ * global reference configuration and apply their material conductivity through
+ * Fourier's law. Compiled integration-point offsets give every element a
+ * disjoint output range, so element recovery can run in parallel without locks
+ * or atomic accumulation. Non-thermal integration-point rows remain zero.
+ *
+ * @param temperature Converged scalar `NODE`-domain temperature field.
+ * @return Three-component global `ELEMENT_IP` heat-flux field.
+ */
+Field Model::compute_heat_flux(const Field& temperature) {
+    // Validate the thermal primary field and compiled integration-point layout
+    logging::error(temperature.domain == FieldDomain::NODE,
+        "Model: heat-flux recovery requires a NODE temperature field");
+    logging::error(temperature.components == 1,
+        "Model: heat-flux recovery requires exactly one temperature component");
+    logging::error(temperature.rows == _data->field_rows(FieldDomain::NODE),
+        "Model: temperature field has the wrong node count");
+    logging::error(_data->element_ip_offsets != nullptr,
+        "Model: element IP offsets have not been initialized");
+
+    const Index total_ips     = _data->field_rows(FieldDomain::ELEMENT_IP);
+    const Index element_count = static_cast<Index>(_data->elements.size());
+
+    // Allocate disjoint global heat-flux rows for every compiled element IP
+    Field heat_flux{"HEAT_FLUX", FieldDomain::ELEMENT_IP, total_ips, 3};
+    heat_flux.set_zero();
+
+    // Prevent nested linear-algebra threading inside parallel element recovery
+    Eigen::setNbThreads(1);
+#ifdef USE_MKL
+    mkl_set_num_threads(1);
+#endif
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static, 1024) num_threads(global_config.max_threads) if(global_config.max_threads > 1)
+#endif
+    // Evaluate Fourier heat flux in each thermal element's private IP range
+    for (Index elem_idx = 0; elem_idx < element_count; ++elem_idx) {
+        const auto& element = _data->elements[static_cast<std::size_t>(elem_idx)];
+        if (element == nullptr) continue;
+
+        if (auto thermal = element->as<ThermalElement>()) {
+            thermal->compute_heat_flux(heat_flux, temperature);
+        }
+    }
+
+    // Restore configured linear-algebra threading after element recovery
+#ifdef USE_MKL
+    mkl_set_num_threads(global_config.max_threads);
+#endif
+    Eigen::setNbThreads(global_config.max_threads);
+
+    // Reject invalid gradients or material coefficients before result output
+    heat_flux.check_finite("Heat flux");
+    return heat_flux;
 }
 
 }

--- a/src/model/model_data.h
+++ b/src/model/model_data.h
@@ -8,19 +8,13 @@
  * coordinate fields consumed by element formulations, constraints, load cases
  * and result writers.
  *
- * The data root also owns shared material/profile definitions, compiled section
- * assignments, global field registration and prefix-sum enumerations for
- * element-nodal, integration-point and material-point storage. FEMaster-native
- * `POINTMASS` definitions are created only after compilation and are therefore
- * kept as auxiliary point elements outside the frozen dense topology.
- *
  * @see Model
  * @see Part
  * @see Instance
  * @see Field
  *
  * @author Finn Eggers
- * @date 25.08.2026
+ * @date 30.08.2026
  */
 
 #pragma once
@@ -28,6 +22,7 @@
 #include "../bc/amplitude.h"
 #include "../bc/load.h"
 #include "../bc/load_collector.h"
+#include "../bc/neumann/thermal_load_collector.h"
 #include "../bc/support.h"
 #include "../bc/support_collector.h"
 #include "../constraints/types/connector.h"
@@ -58,77 +53,28 @@ namespace fem::model {
 struct Part;
 struct Instance;
 
-/**
- * @brief Shared semantic, assembly and solver-facing storage of a FEM model.
- *
- * `ModelData` is the internal ownership root behind `Model`. During model input,
- * Parts contain sparse local topology and Instances define rigid placements of
- * those reusable definitions. Compilation preserves this semantic data for name
- * and identifier resolution while additionally creating dense global arrays for
- * nodes, elements, surfaces, lines, regions and section assignments.
- *
- * Dense element identifiers index `elements` directly. Every represented
- * element stores the corresponding global nodal connectivity and receives
- * prefix offsets into the model-wide `ELEMENT_NODAL`, `ELEMENT_IP` and
- * `ELEMENT_MP` domains. Each offset field has one terminal entry so the span of
- * element `e` is `[offset[e], offset[e + 1])`.
- *
- * `point_elements` are different only in ownership: they are synthesized from
- * FEMaster `POINTMASS, NSET=...` commands after the dense topology has already
- * been compiled. They participate in DOF, stiffness, mass and inertia assembly,
- * but do not alter dense element ids, ELSETs or element-domain fields. Generic
- * non-point features remain supported independently.
- *
- * Named fields are owned through shared pointers in `fields`. Dedicated handles
- * expose fields with central solver meaning, such as current/reference nodal
- * positions, material history and shell reference normals. A dedicated handle
- * may also refer to a registered named field; the registry and handle therefore
- * share ownership rather than duplicate values.
- *
- * The `compiled` flag is monotonic. Once set, semantic topology must no longer be
- * changed because all dense identifiers, regions, offsets and dependent fields
- * rely on the compiled ordering.
- */
 struct ModelData {
-
-    // Semantic topology retained across compilation. Parts own sparse local
-    // entities and regions; instances reference a Part and define its rigid
-    // placement. `compiled` marks the one-way transition to dense assembly data.
     Dict<Part>     parts;
     Dict<Instance> instances;
     bool           compiled = false;
 
-    // mapping global node back to local instance nodes
     std::vector<std::tuple<Instance::Ptr, Index>> node_mapping;
 
-    // Dense assembly topology produced by Model::compile(). Vector indices are
-    // global identifiers, while each Instance retains the corresponding map from
-    // its part-local identifiers.
     std::vector<ElementPtr> elements;
     std::vector<SurfacePtr> surfaces;
     std::vector<LinePtr>    lines;
-
-    // Auxiliary point elements created from post-compile FEMaster POINTMASS
-    // commands. They reference compiled node ids but deliberately stay outside
-    // the frozen dense element namespace and its element-domain enumerations.
     std::vector<ElementPtr> point_elements;
 
-    // Assembly section assignments and shared non-topological definitions.
     std::vector<Section::Ptr>          sections;
     Dict<Profile>                      profiles;
     std::vector<feature::Feature::Ptr> features;
 
-    // Named definitions shared across the complete assembly. Coordinate systems
-    // and amplitudes are global resources rather than part-local topology.
     Dict<material::Material>    materials;
     Dict<cos::CoordinateSystem> coordinate_systems;
     Dict<bc::Amplitude>         amplitudes;
 
-    // Named global fields indexed by their physical FieldDomain
     std::unordered_map<std::string, Field::Ptr> fields;
 
-    // Solver-facing field handles. These may alias entries in `fields`; the
-    // element offset fields are internal prefix sums with one terminal row.
     Field::Ptr positions                   = nullptr;
     Field::Ptr positions_reference         = nullptr;
     Field::Ptr element_stiffness_scale     = nullptr;
@@ -139,14 +85,11 @@ struct ModelData {
     Field::Ptr element_ip_offsets          = nullptr;
     Field::Ptr element_mp_offsets          = nullptr;
 
-    // Global assembly regions materialized from the compiled instances. Every
-    // collection owns an aggregate *ALL region that receives all dense entities.
     Sets<NodeRegion>    node_sets   {SET_NODE_ALL};
     Sets<ElementRegion> elem_sets   {SET_ELEM_ALL};
     Sets<SurfaceRegion> surface_sets{SET_SURF_ALL};
     Sets<LineRegion>    line_sets   {SET_LINE_ALL};
 
-    // Assembly constraints operating on dense global identifiers and regions
     std::vector<constraint::Connector> connectors;
     std::vector<constraint::Coupling>  couplings;
     std::vector<constraint::Tie>       ties;
@@ -154,22 +97,18 @@ struct ModelData {
     std::vector<constraint::Rbm>       rbms;
     std::vector<constraint::Equation>  equations;
 
-    // Named support and load collectors shared by the model load cases
-    Sets<bc::SupportCollector> supp_cols;
-    Sets<bc::LoadCollector>    load_cols;
+    // Essential and natural boundary-condition collectors. Structural loads and
+    // thermal loads intentionally keep distinct collector types because their
+    // algebraic assembly contracts differ (vector force vs scalar K/f terms).
+    Sets<bc::SupportCollector>     supp_cols;
+    Sets<bc::LoadCollector>        load_cols;
+    Sets<bc::ThermalLoadCollector> thermal_load_cols;
 
-    // Construction
     ModelData() = default;
 
-    // Domain sizing and element-local enumeration. Variable-size element domains
-    // use terminal prefix offsets, whereas NODE and ELEMENT derive their row
-    // counts directly from compiled coordinate and topology storage.
     Index field_rows(FieldDomain domain) const;
     void initialize_element_enumeration();
 
-    // Named field lookup and allocation. Registered creation reuses a compatible
-    // existing field; unregistered creation produces independent temporary
-    // storage without changing the global field dictionary.
     bool has_field(const std::string& name) const;
     Field::Ptr get_field(const std::string& name) const;
     Field::Ptr create_field(
@@ -186,9 +125,6 @@ struct ModelData {
         bool              fill_nan = true
     );
 
-    // Weighted projection from element-local nodal rows onto unique global
-    // nodes. Element weights control participation and the relative contribution
-    // of every connected element to the final nodal average.
     Field element_nodal_to_nodal(
         const Field&       element_nodal,
         const Field&       element_weights,

--- a/src/model/model_overview.cpp
+++ b/src/model/model_overview.cpp
@@ -255,7 +255,7 @@ void Model::print_overview() const {
         logging::info(true, name, " (", collector->size(), ")");
         logging::up();
         for (const auto& support : collector->entries()) {
-            logging::info(true, support.str());
+            logging::info(support != nullptr, support ? support->str() : "");
         }
         logging::down();
     }

--- a/src/model/shell/frt_shell.h
+++ b/src/model/shell/frt_shell.h
@@ -638,8 +638,8 @@ struct FRTShell : ShellElement<N> {
     ) override;
     bool compute_shell_section_forces(
         Field&       section_forces,
-        Field&       contribution_count,
-        const Field& displacement
+        const Field& displacement,
+        int          offset
     ) override;
 
 };

--- a/src/model/shell/frt_shell_output.inl
+++ b/src/model/shell/frt_shell_output.inl
@@ -452,22 +452,23 @@ void FRTShell<N>::compute_stress_state(Field&       stress_state,
 }
 
 /**
- * Averages generalized shell resultants from the element nodes into nodal
- * result fields.
+ * Recovers generalized shell resultants at the element nodes.
  *
  * Each natural nodal output coordinate reuses the closest in-plane integration-
  * point state block. The section evaluates resultants in its configured output
- * basis before they are accumulated for subsequent component-wise averaging.
+ * basis before they are written to the element's disjoint output rows. The
+ * model subsequently projects participating element-nodal values to global
+ * nodes.
  *
- * @param resultants Global nodal generalized-resultant accumulator.
- * @param contribution_count Global nodal contribution counter.
+ * @param resultants Global element-nodal generalized-resultant field.
  * @param displacement Global nodal displacement field.
- * @return Always `true` after shell resultants were accumulated.
+ * @param offset First element-nodal output row belonging to this element.
+ * @return Always `true` after shell resultants were written.
  */
 template<Index N>
 bool FRTShell<N>::compute_shell_section_forces(Field&       resultants,
-                                               Field&       contribution_count,
-                                               const Field& displacement) {
+                                               const Field& displacement,
+                                               int          offset) {
     logging::error(resultants.components >= num_strains,
                    "FRTShell: shell section forces require eight components "
                    "[N11,N22,N12,M11,M22,M12,Q13,Q23]");
@@ -532,13 +533,11 @@ bool FRTShell<N>::compute_shell_section_forces(Field&       resultants,
         );
         const Vec8 values = scale * output_resultants.values();
 
-        const Index node_id = static_cast<Index>(this->node_ids[node]);
+        const Index row = static_cast<Index>(offset) + node;
 
         for (Index component = 0; component < num_strains; ++component) {
-            resultants(node_id, component) += values(component);
+            resultants(row, component) = values(component);
         }
-
-        contribution_count(node_id, 0) += Precision(1);
     }
 
     return true;

--- a/src/model/shell/shell_simple.h
+++ b/src/model/shell/shell_simple.h
@@ -891,8 +891,8 @@ struct DefaultShellElement : public ShellElement<N> {
     }
 
     bool compute_shell_section_forces(Field& resultants,
-                                      Field& contribution_count,
-                                      const Field& displacement) override {
+                                      const Field& displacement,
+                                      int offset) override {
         // Construct the fixed element-local shell basis used by this legacy formulation
         Mat3 axes        = get_xyz_axes();
         Mat3 shell_basis = axes.transpose();
@@ -939,8 +939,6 @@ struct DefaultShellElement : public ShellElement<N> {
         const auto&        scheme    = this->integration_scheme();
 
         for (Index i = 0; i < N; ++i) {
-            ID node_id = this->nodes()[i];
-
             Precision r = coords(i, 0);
             Precision s = coords(i, 1);
 
@@ -1000,12 +998,11 @@ struct DefaultShellElement : public ShellElement<N> {
 
             const Vec8 values = topo_scale * output_resultants.values();
 
-            const Index node_idx = static_cast<Index>(node_id);
+            const Index row = static_cast<Index>(offset) + i;
 
             for (Index component = 0; component < 8; ++component) {
-                resultants(node_idx, component) += values(component);
+                resultants(row, component) = values(component);
             }
-            contribution_count(node_idx, 0) += Precision(1);
         }
         return true;
     }

--- a/src/model/shell/shell_thermal.h
+++ b/src/model/shell/shell_thermal.h
@@ -1,0 +1,133 @@
+/**
+ * @file shell_thermal.h
+ * @brief Adds in-plane heat conduction to simple shell elements.
+ */
+
+#pragma once
+
+#include "s3.h"
+#include "s4.h"
+#include "../element/element_thermal.h"
+
+#include <cmath>
+
+namespace fem::model {
+
+template<class Base, Index N>
+struct ThermalShell : Base, ThermalElement {
+    ThermalShell(ID elem_id, std::array<ID, N> node_ids)
+        : Base(elem_id, node_ids) {}
+
+    ElementPtr copy() const override {
+        return std::make_shared<ThermalShell<Base, N>>(this->elem_id, this->node_ids);
+    }
+
+    MapMatrix conductivity(Precision* buffer) override {
+        auto material = this->get_material();
+        logging::error(material->has_thermal_conductivity(),
+            this->type_name(), ": material has no thermal conductivity for element ", this->elem_id);
+
+        const Precision conductivity = material->get_thermal_conductivity();
+        const Precision thickness    = this->get_section()->thickness_;
+        auto axes      = this->get_xyz_axes();
+        auto xy_coords = this->get_xy_coords(axes);
+        const auto& scheme = this->integration_scheme();
+
+        StaticMatrix<N, N> matrix = StaticMatrix<N, N>::Zero();
+        for (Index ip = 0; ip < scheme.count(); ++ip) {
+            const auto point = scheme.get_point(ip);
+            auto dH = this->shape_derivative(point.r, point.s);
+            auto jac = this->jacobian(dH, xy_coords);
+            const Precision det = std::abs(jac.determinant());
+            logging::error(det > Precision(0),
+                this->type_name(), ": degenerate thermal shell element ", this->elem_id);
+
+            const auto dH_xy = dH * jac.inverse();
+            matrix.noalias() += conductivity * thickness * point.w * det
+                              * (dH_xy * dH_xy.transpose());
+        }
+
+        matrix = Precision(0.5) * (matrix + matrix.transpose());
+        MapMatrix mapped(buffer, N, N);
+        mapped = matrix;
+        return mapped;
+    }
+
+    MapMatrix capacity(Precision* buffer) override {
+        auto material = this->get_material();
+        logging::error(material->has_density(),
+            this->type_name(), ": material has no density for element ", this->elem_id);
+        logging::error(material->has_thermal_specific_heat(),
+            this->type_name(), ": material has no specific heat for element ", this->elem_id);
+
+        const Precision scale = material->get_density()
+                              * material->get_thermal_specific_heat()
+                              * this->get_section()->thickness_;
+        auto axes      = this->get_xyz_axes();
+        auto xy_coords = this->get_xy_coords(axes);
+        const auto& scheme = this->integration_scheme();
+
+        StaticMatrix<N, N> matrix = StaticMatrix<N, N>::Zero();
+        for (Index ip = 0; ip < scheme.count(); ++ip) {
+            const auto point = scheme.get_point(ip);
+            const auto H = this->shape_function(point.r, point.s);
+            auto dH = this->shape_derivative(point.r, point.s);
+            auto jac = this->jacobian(dH, xy_coords);
+            const Precision det = std::abs(jac.determinant());
+            matrix.noalias() += scale * point.w * det * (H * H.transpose());
+        }
+
+        matrix = Precision(0.5) * (matrix + matrix.transpose());
+        MapMatrix mapped(buffer, N, N);
+        mapped = matrix;
+        return mapped;
+    }
+
+    void compute_heat_flux(Field& heat_flux, const Field& temperature) override {
+        logging::error(heat_flux.domain == FieldDomain::ELEMENT_IP,
+            this->type_name(), ": heat flux output must use ELEMENT_IP domain");
+        logging::error(heat_flux.components >= 3,
+            this->type_name(), ": heat flux output requires three components");
+        logging::error(temperature.domain == FieldDomain::NODE && temperature.components == 1,
+            this->type_name(), ": temperature must be a scalar NODE field");
+
+        auto material = this->get_material();
+        logging::error(material->has_thermal_conductivity(),
+            this->type_name(), ": material has no thermal conductivity for element ", this->elem_id);
+        const Precision conductivity = material->get_thermal_conductivity();
+
+        StaticVector<N> local_temperature;
+        for (Index i = 0; i < N; ++i) {
+            local_temperature(i) = temperature(static_cast<Index>(this->node_ids[i]), 0);
+        }
+
+        auto axes      = this->get_xyz_axes();
+        auto xy_coords = this->get_xy_coords(axes);
+        const auto& scheme = this->integration_scheme();
+
+        for (Index ip = 0; ip < scheme.count(); ++ip) {
+            const auto point = scheme.get_point(ip);
+            auto dH = this->shape_derivative(point.r, point.s);
+            auto jac = this->jacobian(dH, xy_coords);
+            const Precision det = std::abs(jac.determinant());
+            logging::error(det > Precision(0),
+                this->type_name(), ": degenerate thermal shell element ", this->elem_id);
+
+            const auto dH_xy = dH * jac.inverse();
+            const Vec2 gradient = dH_xy.transpose() * local_temperature;
+            const Vec2 local_flux = -conductivity * gradient;
+            const Vec3 global_flux = axes.row(0).transpose() * local_flux(0)
+                                   + axes.row(1).transpose() * local_flux(1);
+
+            const Index row = this->ip_index(ip);
+            for (Dim component = 0; component < 3; ++component) {
+                heat_flux(row, component) = global_flux(component);
+            }
+        }
+    }
+};
+
+using ThermalS3 = ThermalShell<S3, 3>;
+using ThermalS4 = ThermalShell<S4, 4>;
+
+} // namespace fem::model

--- a/src/model/solid/element_solid.h
+++ b/src/model/solid/element_solid.h
@@ -3,8 +3,8 @@
  * @brief Declares the common three-dimensional solid element formulation.
  *
  * `SolidElement` provides reference/current geometry, material evaluation,
- * strain-displacement operators and the common Total-Lagrangian nonlinear
- * assembly used by the concrete C3D solid topologies.
+ * strain-displacement operators, Total-Lagrangian nonlinear assembly and scalar
+ * heat-transfer operations used by the concrete C3D solid topologies.
  *
  * Every constitutive integration point is associated with one globally
  * enumerated material-point row. The element addresses that row directly in
@@ -36,13 +36,15 @@ namespace fem::model {
  *
  * Concrete solid elements provide topology-specific interpolation and
  * quadrature. The base implements geometry transformations, constitutive
- * evaluation and common linear/nonlinear assembly. In nonlinear tangent
- * assembly each material point is evaluated exactly once so an in-place
+ * evaluation and common linear/nonlinear assembly. The orthogonal thermal
+ * capability supplies conductivity, capacity and Fourier heat-flux evaluation
+ * using the same reference geometry and material assignment. In nonlinear
+ * tangent assembly each material point is evaluated exactly once so an in-place
  * constitutive history state cannot advance twice within one residual/tangent
  * evaluation.
  */
 template<Index N>
-struct SolidElement : StructuralElement, ThermalElement{
+struct SolidElement : StructuralElement, ThermalElement {
     static constexpr Dim D        = 3;
     static constexpr Dim n_strain = 6;
 

--- a/src/model/truss/t3d2_thermal.h
+++ b/src/model/truss/t3d2_thermal.h
@@ -1,0 +1,87 @@
+/**
+ * @file t3d2_thermal.h
+ * @brief Adds one-dimensional heat conduction to the two-node truss topology.
+ */
+
+#pragma once
+
+#include "truss.h"
+#include "../element/element_thermal.h"
+
+namespace fem::model {
+
+struct ThermalT3D2 : T3, ThermalElement {
+    ThermalT3D2(ID elem_id, std::array<ID, 2> node_ids)
+        : T3(elem_id, node_ids) {}
+
+    ElementPtr copy() const override {
+        return std::make_shared<ThermalT3D2>(elem_id, node_ids);
+    }
+
+    std::string type_name() const override { return "T3D2"; }
+
+    MapMatrix conductivity(Precision* buffer) override {
+        auto material = get_material();
+        logging::error(material->has_thermal_conductivity(),
+            "T3D2: material has no thermal conductivity for element ", elem_id);
+
+        const Precision length = length_reference();
+        logging::error(length > Precision(0),
+            "T3D2: zero reference length for element ", elem_id);
+
+        const Precision scale = material->get_thermal_conductivity()
+                              * get_section()->area_ / length;
+
+        MapMatrix matrix(buffer, 2, 2);
+        matrix << scale, -scale,
+                 -scale,  scale;
+        return matrix;
+    }
+
+    MapMatrix capacity(Precision* buffer) override {
+        auto material = get_material();
+        logging::error(material->has_density(),
+            "T3D2: material has no density for element ", elem_id);
+        logging::error(material->has_thermal_specific_heat(),
+            "T3D2: material has no specific heat for element ", elem_id);
+
+        const Precision length = length_reference();
+        const Precision scale = material->get_density()
+                              * material->get_thermal_specific_heat()
+                              * get_section()->area_ * length / Precision(6);
+
+        MapMatrix matrix(buffer, 2, 2);
+        matrix << Precision(2) * scale, scale,
+                  scale, Precision(2) * scale;
+        return matrix;
+    }
+
+    void compute_heat_flux(Field& heat_flux, const Field& temperature) override {
+        logging::error(heat_flux.domain == FieldDomain::ELEMENT_IP,
+            "T3D2: heat flux output must use ELEMENT_IP domain");
+        logging::error(heat_flux.components >= 3,
+            "T3D2: heat flux output requires three components");
+        logging::error(temperature.domain == FieldDomain::NODE && temperature.components == 1,
+            "T3D2: temperature must be a scalar NODE field");
+
+        auto material = get_material();
+        logging::error(material->has_thermal_conductivity(),
+            "T3D2: material has no thermal conductivity for element ", elem_id);
+
+        const Precision length = length_reference();
+        logging::error(length > Precision(0),
+            "T3D2: zero reference length for element ", elem_id);
+
+        const Precision t0 = temperature(static_cast<Index>(node_ids[0]), 0);
+        const Precision t1 = temperature(static_cast<Index>(node_ids[1]), 0);
+        const Vec3 flux = -material->get_thermal_conductivity()
+                        * (t1 - t0) / length * direction_reference();
+
+        const Index row = ip_index(0);
+        for (Dim component = 0; component < 3; ++component) {
+            heat_flux(row, component) = flux(component);
+        }
+    }
+};
+
+} // namespace fem::model


### PR DESCRIPTION
## Summary

- introduce a common support interface and store prescribed temperatures in support collectors
- add conductivity and temperature parser commands plus a steady-state thermal load case
- assemble the thermal conductivity system and recover nodal temperatures and integration-point heat flux
- parallelize shell section-resultant recovery through disjoint element-nodal storage

## Testing

- not run; compilation and runtime verification are being performed locally by the requester

## Scope

- generated result files and thermal example decks are intentionally excluded