### PR TITLE
Separate material state input and output buffers

### DIFF
--- a/src/loadcase/tools/nonlinear_state_manager.cpp
+++ b/src/loadcase/tools/nonlinear_state_manager.cpp
@@ -2,10 +2,9 @@
  * @file nonlinear_state_manager.cpp
  * @brief Implements nonlinear material and contact state management.
  *
- * Material history is represented by committed and trial material-point fields.
- * Independent residual and tangent evaluations restart from committed material
- * history and may overwrite the active trial field without modifying the last
- * accepted constitutive state.
+ * Material history is represented by committed input and trial output fields.
+ * Every constitutive evaluation reads only the committed material history and
+ * may overwrite the trial field without modifying the last accepted state.
  *
  * Surface-to-surface contact owns its augmented-Lagrange multiplier history and
  * nested trial stack internally. This manager only coordinates begin, commit and
@@ -37,77 +36,63 @@ namespace tools {
 /**
  * Creates the nonlinear state coordinator for one load-case execution.
  *
- * The caller-visible material-state pointer is saved first and restored by the
- * destructor. Contact penalty adaptation is reset once here, which returns each
- * contact to its user-provided starting penalty while deliberately allowing later
+ * Contact penalty adaptation is reset once here, which returns each contact to
+ * its user-provided starting penalty while deliberately allowing later
  * adaptations to persist across load increments and cutbacks within this
  * analysis.
  *
- * If assigned materials require history variables, matching committed and trial
- * `ELEMENT_MP` fields are allocated and initialized in the global material-point
- * enumeration owned by `ModelData`. Models without constitutive history avoid
- * allocating those fields entirely.
+ * If assigned materials require history variables, the two enumerated
+ * `ELEMENT_MP` fields are resized to the required state width and initialized.
+ * Models without constitutive history retain their default input/output rows.
  *
  * @param model Model whose material and contact state is coordinated.
  */
 NonlinearStateManager::NonlinearStateManager(model::Model& model)
-    : model_(model),
-      previous_material_state_(model._data->material_state) {
+    : model_(model) {
     // Penalty continuation belongs to the complete nonlinear analysis, not to
     // individual increments. Reset it exactly once when the manager is created.
     for (const auto& contact : model_._data->contacts) {
         contact.reset_penalty_adaptation();
     }
 
-    const Index state_size = model_.maximum_material_state_size();
-    if (state_size == 0) {
+    material_state_size_ = model_.maximum_material_state_size();
+    if (material_state_size_ == 0) {
         return;
     }
 
-    // Allocate separate accepted and working constitutive history fields. Both
-    // use the same global element/material-point row ordering.
-    committed_material_state_ = model_._data->create_field(
-        "MATERIAL_STATE_COMMITTED",
-        model::FieldDomain::ELEMENT_MP,
-        state_size,
-        false,
-        false
-    );
+    // Reuse the two fields created during material-point enumeration so only
+    // the committed input and trial output buffers exist.
+    logging::error(model_._data->material_state_old != nullptr,
+        "Nonlinear material input state is not initialized");
+    logging::error(model_._data->material_state_new != nullptr,
+        "Nonlinear material output state is not initialized");
+    logging::error(model_._data->material_state_old != model_._data->material_state_new,
+        "Nonlinear material input and output states must use separate storage");
 
-    trial_material_state_ = model_._data->create_field(
-        "MATERIAL_STATE",
-        model::FieldDomain::ELEMENT_MP,
-        state_size,
-        false,
-        false
-    );
+    const Index material_points = model_._data->field_rows(model::FieldDomain::ELEMENT_MP);
+    *model_._data->material_state_old = model::Field(
+        "MATERIAL_STATE_OLD", model::FieldDomain::ELEMENT_MP, material_points, material_state_size_);
+    *model_._data->material_state_new = model::Field(
+        "MATERIAL_STATE_NEW", model::FieldDomain::ELEMENT_MP, material_points, material_state_size_);
 
-    model_.initialize_material_state(*committed_material_state_);
+    model_.initialize_material_state(*model_._data->material_state_old);
     reset_material_state();
-}
-
-/**
- * Restores the material-state field that was visible before this manager was
- * created. The manager-owned committed/trial buffers then leave scope normally.
- */
-NonlinearStateManager::~NonlinearStateManager() {
-    model_._data->material_state = previous_material_state_;
 }
 
 /**
  * Restarts the active constitutive trial from the last committed material state.
  *
- * Independent Newton, predictor and line-search evaluations must not inherit
- * in-place material updates from a previously rejected evaluation. Copying the
- * committed values before rebinding the trial field provides that isolation.
+ * Independent Newton, predictor and line-search evaluations write a fresh trial
+ * field while continuing to read the committed state. Copying the committed
+ * values also preserves unused components and deterministic trial contents.
  */
 void NonlinearStateManager::reset_material_state() {
-    if (!committed_material_state_) {
+    if (material_state_size_ == 0) {
         return;
     }
 
-    trial_material_state_->values = committed_material_state_->values;
-    bind_material_state();
+    model_._data->material_state_new->values = model_._data->material_state_old->values;
+    name_material_states();
 }
 
 /**
@@ -118,13 +103,13 @@ void NonlinearStateManager::reset_material_state() {
  * state so the next independent evaluation starts from identical history.
  */
 void NonlinearStateManager::commit_material_state() {
-    if (!committed_material_state_) {
+    if (material_state_size_ == 0) {
         return;
     }
 
-    std::swap(committed_material_state_, trial_material_state_);
-    trial_material_state_->values = committed_material_state_->values;
-    bind_material_state();
+    std::swap(model_._data->material_state_old, model_._data->material_state_new);
+    model_._data->material_state_new->values = model_._data->material_state_old->values;
+    name_material_states();
 }
 
 /**
@@ -196,13 +181,12 @@ bool NonlinearStateManager::update_contact_active_set() {
 }
 
 /**
- * Publishes the manager-owned trial material field as the active constitutive
- * history and restores the semantic names of committed and trial buffers.
+ * Restores the semantic names of the committed input and trial output fields
+ * after their pointers have been swapped by a material-state commit.
  */
-void NonlinearStateManager::bind_material_state() {
-    committed_material_state_->name = "MATERIAL_STATE_COMMITTED";
-    trial_material_state_->name     = "MATERIAL_STATE";
-    model_._data->material_state    = trial_material_state_;
+void NonlinearStateManager::name_material_states() {
+    model_._data->material_state_old->name = "MATERIAL_STATE_OLD";
+    model_._data->material_state_new->name = "MATERIAL_STATE_NEW";
 }
 
 } // namespace tools

--- a/src/loadcase/tools/nonlinear_state_manager.h
+++ b/src/loadcase/tools/nonlinear_state_manager.h
@@ -2,10 +2,11 @@
  * @file nonlinear_state_manager.h
  * @brief Defines nonlinear material and contact state management.
  *
- * The nonlinear state manager owns material-point history buffers and coordinates
- * the transactional augmented-Lagrange state maintained by surface-to-surface
- * contact. Contact geometry is always reconstructed from current nodal positions
- * and is never frozen or stored between evaluations.
+ * The nonlinear state manager coordinates the committed and trial material-point
+ * history buffers stored by `ModelData` and the transactional augmented-Lagrange
+ * state maintained by surface-to-surface contact. Contact geometry is always
+ * reconstructed from current nodal positions and is never stored between
+ * evaluations.
  *
  * Material history is committed per accepted physical increment. Contact
  * multiplier trials follow the nested predictor, line-search and augmentation
@@ -14,7 +15,8 @@
  * managed by the contact definition itself.
  *
  * @see constraint::Contact
- * @see model::ModelData::material_state
+ * @see model::ModelData::material_state_old
+ * @see model::ModelData::material_state_new
  * @see tools::LoadControl
  * @see tools::ArcLengthControl
  *
@@ -35,12 +37,12 @@ namespace loadcase {
 namespace tools {
 
 /**
- * @brief Owns nonlinear material history and coordinates contact trial state.
+ * @brief Coordinates nonlinear material history and contact trial state.
  *
- * Material evaluations overwrite an active trial field in place and therefore
- * restart from committed history for every independent residual or tangent
- * evaluation. Accepted increments promote the trial constitutive state to the
- * committed field.
+ * Material evaluations read the committed field and write a separate trial
+ * field. Independent residual and tangent evaluations therefore cannot advance
+ * their own input history. Accepted increments promote the trial constitutive
+ * state to the committed field.
  *
  * Surface contact retains its own nested augmented-Lagrange state. This manager
  * only synchronizes contact begin/commit/rollback operations with the path
@@ -50,7 +52,7 @@ namespace tools {
 class NonlinearStateManager {
 public:
     explicit NonlinearStateManager(model::Model& model);
-    ~NonlinearStateManager();
+    ~NonlinearStateManager() = default;
 
     NonlinearStateManager(const NonlinearStateManager&)            = delete;
     NonlinearStateManager& operator=(const NonlinearStateManager&) = delete;
@@ -68,16 +70,14 @@ public:
     bool update_contact_active_set();
 
 private:
-    // Publish the trial material field as the active ModelData state
-    void bind_material_state();
+    // Restore semantic field names after committed/trial pointer swaps
+    void name_material_states();
 
     // Model whose nonlinear state is coordinated
     model::Model& model_;
 
-    // Caller-visible material state and manager-owned committed/trial buffers
-    model::Field::Ptr previous_material_state_  = nullptr;
-    model::Field::Ptr committed_material_state_ = nullptr;
-    model::Field::Ptr trial_material_state_     = nullptr;
+    // Uniform constitutive history width; zero denotes stateless materials
+    Index material_state_size_ = 0;
 };
 
 } // namespace tools

--- a/src/material/elasticity.cpp
+++ b/src/material/elasticity.cpp
@@ -69,77 +69,91 @@ void Elasticity::initialize_state(Precision* state) const {
 }
 
 void Elasticity::evaluate(const AxialStrainLinearized& strain,
-                          Precision*                   state,
+                          const Precision*             old_state,
+                          Precision*                   new_state,
                           AxialStressCauchy&           stress,
                           Precision&                   tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) stress;
     (void) tangent;
     logging::error(false, "Elasticity model does not support linearized axial evaluation");
 }
 
 void Elasticity::evaluate(const AxialStrainGreenLagrange& strain,
-                          Precision*                      state,
+                          const Precision*                old_state,
+                          Precision*                      new_state,
                           AxialStressPK2&                 stress,
                           Precision&                      tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) stress;
     (void) tangent;
     logging::error(false, "Elasticity model does not support Green-Lagrange axial evaluation");
 }
 
 void Elasticity::evaluate(const VolumeStrainLinearized& strain,
-                          Precision*                    state,
+                          const Precision*              old_state,
+                          Precision*                    new_state,
                           VolumeStressCauchy&           stress,
                           Mat6&                         tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) stress;
     (void) tangent;
     logging::error(false, "Elasticity model does not support linearized volume evaluation");
 }
 
 void Elasticity::evaluate(const VolumeStrainGreenLagrange& strain,
-                          Precision*                       state,
+                          const Precision*                 old_state,
+                          Precision*                       new_state,
                           VolumeStressPK2&                 stress,
                           Mat6&                            tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) stress;
     (void) tangent;
     logging::error(false, "Elasticity model does not support Green-Lagrange volume evaluation");
 }
 
 void Elasticity::evaluate(const BeamGeneralizedStrain& strain,
-                          Precision*                   state,
+                          const Precision*             old_state,
+                          Precision*                   new_state,
                           BeamStressResultants&        resultants,
                           Mat6&                        tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) resultants;
     (void) tangent;
     logging::error(false, "Elasticity model does not support beam-resultant evaluation");
 }
 
 void Elasticity::evaluate(const ShellMaterialStrainLinearized& strain,
-                          Precision*                           state,
+                          const Precision*                     old_state,
+                          Precision*                           new_state,
                           ShellMaterialStressCauchy&            stress,
                           Mat5&                                 tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) stress;
     (void) tangent;
     logging::error(false, "Elasticity model does not support linearized shell integration");
 }
 
 void Elasticity::evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                          Precision*                              state,
+                          const Precision*                        old_state,
+                          Precision*                              new_state,
                           ShellMaterialStressPK2&                 stress,
                           Mat5&                                   tangent) const {
     (void) strain;
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     (void) stress;
     (void) tangent;
     logging::error(false, "Elasticity model does not support Green-Lagrange shell integration");

--- a/src/material/elasticity.h
+++ b/src/material/elasticity.h
@@ -7,11 +7,11 @@
  * dimensional reduction; implementations return the work-conjugate stress and
  * consistent tangent in the same material basis.
  *
- * Every evaluation receives the mutable state row of the current material
- * point. Stateless elastic laws leave that row unchanged, while history-
- * dependent implementations may update it in place. Ownership, reset and
- * commitment of these rows belong to the nonlinear state manager rather than
- * to the constitutive model.
+ * Every evaluation receives separate input and output state rows for the current
+ * material point. The input row is always valid and remains unchanged, while a
+ * history-dependent implementation writes its updated history to the output
+ * row. Ownership and commitment of these rows belong to the nonlinear state
+ * manager rather than to the constitutive model.
  *
  * @see material::Material
  * @see loadcase::tools::NonlinearStateManager
@@ -59,10 +59,11 @@ namespace material {
  * kinematics before evaluation. The base implementations report no supported
  * formulation and raise a model error if an unsupported overload is called.
  *
- * Material-point state is passed as mutable, non-owning storage. `state_size()`
- * defines the required leading components, and `initialize_state()` establishes
- * their reference history. A size of zero denotes a stateless model; callers
- * may still pass a valid dummy row to keep addressing uniform.
+ * Material-point state is passed as non-owning input/output storage.
+ * `state_size()` defines the required leading components, and
+ * `initialize_state()` establishes their reference history. A size of zero
+ * denotes a stateless model; callers still pass valid dummy rows to keep
+ * addressing uniform.
  */
 struct Elasticity {
     // Shared ownership used by material definitions
@@ -90,11 +91,16 @@ struct Elasticity {
     virtual Index state_size() const;
     virtual void  initialize_state(Precision* state) const;
 
+    // Every constitutive evaluation receives valid, separate state rows.
+    // Implementations read old_state without modifying it and write all updated
+    // history components to new_state.
+
     // Infinitesimal axial response in the material direction. The caller owns
-    // state and passes the row of the current material point. stress is Cauchy
-    // stress and tangent is d(sigma)/d(epsilon).
+    // the immutable old_state and mutable new_state rows of the current material
+    // point. stress is Cauchy stress and tangent is d(sigma)/d(epsilon).
     virtual void evaluate(const AxialStrainLinearized& strain,
-                          Precision*                   state,
+                          const Precision*             old_state,
+                          Precision*                   new_state,
                           AxialStressCauchy&           stress,
                           Precision&                   tangent) const;
 
@@ -102,7 +108,8 @@ struct Elasticity {
     // is second Piola-Kirchhoff stress work-conjugate to Green-Lagrange strain;
     // tangent is the consistent derivative dS/dE.
     virtual void evaluate(const AxialStrainGreenLagrange& strain,
-                          Precision*                      state,
+                          const Precision*                old_state,
+                          Precision*                      new_state,
                           AxialStressPK2&                 stress,
                           Precision&                      tangent) const;
 
@@ -110,7 +117,8 @@ struct Elasticity {
     // ordering follows VolumeStrain/VolumeStress, and tangent maps engineering
     // strain components to Cauchy-stress components.
     virtual void evaluate(const VolumeStrainLinearized& strain,
-                          Precision*                    state,
+                          const Precision*              old_state,
+                          Precision*                    new_state,
                           VolumeStressCauchy&           stress,
                           Mat6&                         tangent) const;
 
@@ -118,15 +126,17 @@ struct Elasticity {
     // basis. Green-Lagrange strain, PK2 stress and dS/dE remain work-conjugate;
     // the owning section handles transformations to and from global coordinates.
     virtual void evaluate(const VolumeStrainGreenLagrange& strain,
-                          Precision*                       state,
+                          const Precision*                 old_state,
+                          Precision*                       new_state,
                           VolumeStressPK2&                 stress,
                           Mat6&                            tangent) const;
 
     // Generalized beam response. The section-defined six-component strain and
     // resultant ordering is preserved, and tangent is their consistent local
-    // derivative. The state row has the same non-owning in-place semantics.
+    // derivative. State follows the same separate input/output convention.
     virtual void evaluate(const BeamGeneralizedStrain& strain,
-                          Precision*                   state,
+                          const Precision*             old_state,
+                          Precision*                   new_state,
                           BeamStressResultants&        resultants,
                           Mat6&                        tangent) const;
 
@@ -134,7 +144,8 @@ struct Elasticity {
     // The five strain components exclude thickness-normal strain; stress is
     // Cauchy stress under the material's plane-stress reduction.
     virtual void evaluate(const ShellMaterialStrainLinearized& strain,
-                          Precision*                           state,
+                          const Precision*                     old_state,
+                          Precision*                           new_state,
                           ShellMaterialStressCauchy&            stress,
                           Mat5&                                 tangent) const;
 
@@ -142,7 +153,8 @@ struct Elasticity {
     // The five-component Green-Lagrange input returns work-conjugate PK2 stress
     // and the consistently reduced tangent under the model's S33 = 0 convention.
     virtual void evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                          Precision*                              state,
+                          const Precision*                        old_state,
+                          Precision*                              new_state,
                           ShellMaterialStressPK2&                 stress,
                           Mat5&                                   tangent) const;
 

--- a/src/material/generalised_isotropic_elasticity.cpp
+++ b/src/material/generalised_isotropic_elasticity.cpp
@@ -139,15 +139,18 @@ Mat6 GeneralisedIsotropicElasticity::volume_tangent() const {
  * not enter this one-dimensional response.
  *
  * @param strain Infinitesimal axial strain.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Axial Cauchy stress.
  * @param tangent Constant derivative equal to Young's modulus.
  */
 void GeneralisedIsotropicElasticity::evaluate(const AxialStrainLinearized& strain,
-                                              Precision*                   state,
+                                              const Precision*             old_state,
+                                              Precision*                   new_state,
                                               AxialStressCauchy&           stress,
                                               Precision&                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = youngs;
     stress.value() = tangent * strain.value();
 }
@@ -156,15 +159,18 @@ void GeneralisedIsotropicElasticity::evaluate(const AxialStrainLinearized& strai
  * Evaluates axial PK2 stress from Green-Lagrange strain.
  *
  * @param strain Axial Green-Lagrange strain.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Axial second Piola-Kirchhoff stress.
  * @param tangent Constant material derivative equal to Young's modulus.
  */
 void GeneralisedIsotropicElasticity::evaluate(const AxialStrainGreenLagrange& strain,
-                                              Precision*                      state,
+                                              const Precision*                old_state,
+                                              Precision*                      new_state,
                                               AxialStressPK2&                 stress,
                                               Precision&                      tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = youngs;
     stress.value() = tangent * strain.value();
 }
@@ -173,15 +179,18 @@ void GeneralisedIsotropicElasticity::evaluate(const AxialStrainGreenLagrange& st
  * Evaluates linearized three-dimensional Cauchy stress in material coordinates.
  *
  * @param strain Infinitesimal engineering strain vector.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Cauchy stress in engineering-Voigt ordering.
  * @param tangent Constant generalized isotropic tangent.
  */
 void GeneralisedIsotropicElasticity::evaluate(const VolumeStrainLinearized& strain,
-                                              Precision*                    state,
+                                              const Precision*              old_state,
+                                              Precision*                    new_state,
                                               VolumeStressCauchy&           stress,
                                               Mat6&                         tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = volume_tangent();
     stress.voigt() = tangent * strain.voigt();
 }
@@ -190,15 +199,18 @@ void GeneralisedIsotropicElasticity::evaluate(const VolumeStrainLinearized& stra
  * Evaluates three-dimensional PK2 stress from Green-Lagrange strain.
  *
  * @param strain Green-Lagrange engineering strain vector.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Second Piola-Kirchhoff stress in material coordinates.
  * @param tangent Constant material derivative `dS/dE`.
  */
 void GeneralisedIsotropicElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
-                                              Precision*                       state,
+                                              const Precision*                 old_state,
+                                              Precision*                       new_state,
                                               VolumeStressPK2&                 stress,
                                               Mat6&                            tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = volume_tangent();
     stress.voigt() = tangent * strain.voigt();
 }
@@ -207,15 +219,18 @@ void GeneralisedIsotropicElasticity::evaluate(const VolumeStrainGreenLagrange& s
  * Evaluates linearized shell Cauchy stress with independent shear response.
  *
  * @param strain Five-component shell material strain.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Shell Cauchy stress in material ordering.
  * @param tangent Constant reduced shell tangent.
  */
 void GeneralisedIsotropicElasticity::evaluate(const ShellMaterialStrainLinearized& strain,
-                                              Precision*                           state,
+                                              const Precision*                     old_state,
+                                              Precision*                           new_state,
                                               ShellMaterialStressCauchy&            stress,
                                               Mat5&                                 tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent         = shell_material_tangent();
     stress.values() = tangent * strain.values();
 }
@@ -224,15 +239,18 @@ void GeneralisedIsotropicElasticity::evaluate(const ShellMaterialStrainLinearize
  * Evaluates shell PK2 stress from five-component Green-Lagrange strain.
  *
  * @param strain Shell Green-Lagrange material strain.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Shell second Piola-Kirchhoff stress.
  * @param tangent Constant reduced material derivative.
  */
 void GeneralisedIsotropicElasticity::evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                                              Precision*                              state,
+                                              const Precision*                        old_state,
+                                              Precision*                              new_state,
                                               ShellMaterialStressPK2&                 stress,
                                               Mat5&                                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent         = shell_material_tangent();
     stress.values() = tangent * strain.values();
 }

--- a/src/material/generalised_isotropic_elasticity.h
+++ b/src/material/generalised_isotropic_elasticity.h
@@ -28,8 +28,8 @@ namespace fem::material {
  * in three-dimensional and shell tangents. Responses are evaluated in the
  * material basis supplied by the owning section.
  *
- * The constitutive law contains no history variables and never modifies the
- * material-point state pointer passed through `Elasticity`.
+ * The constitutive law contains no history variables and never uses the
+ * material-point state pointers passed through `Elasticity`.
  */
 struct GeneralisedIsotropicElasticity : Elasticity {
     // Independent elastic parameters
@@ -55,42 +55,48 @@ struct GeneralisedIsotropicElasticity : Elasticity {
     // Linearized axial response sigma = E epsilon. Independent shear stiffness
     // does not enter this one-dimensional reduction; state remains unchanged.
     void evaluate(const AxialStrainLinearized& strain,
-                  Precision*                   state,
+                  const Precision*             old_state,
+                  Precision*                   new_state,
                   AxialStressCauchy&           stress,
                   Precision&                   tangent) const override;
 
     // Total-Lagrangian axial response S = E E_GL with constant tangent E.
     // The returned PK2 stress is work-conjugate to Green-Lagrange strain.
     void evaluate(const AxialStrainGreenLagrange& strain,
-                  Precision*                      state,
+                  const Precision*                old_state,
+                  Precision*                      new_state,
                   AxialStressPK2&                 stress,
                   Precision&                      tangent) const override;
 
     // Linearized three-dimensional response. Normal entries follow isotropic
     // E/nu coupling, while all engineering shear diagonals use the supplied G.
     void evaluate(const VolumeStrainLinearized& strain,
-                  Precision*                    state,
+                  const Precision*              old_state,
+                  Precision*                    new_state,
                   VolumeStressCauchy&           stress,
                   Mat6&                         tangent) const override;
 
     // Finite-strain response with the identical constant material operator,
     // interpreted as the mapping from Green-Lagrange strain to PK2 stress.
     void evaluate(const VolumeStrainGreenLagrange& strain,
-                  Precision*                       state,
+                  const Precision*                 old_state,
+                  Precision*                       new_state,
                   VolumeStressPK2&                 stress,
                   Mat6&                            tangent) const override;
 
     // Linearized shell plane-stress response. The in-plane normal block uses
     // E and nu; in-plane and transverse engineering shear terms use G.
     void evaluate(const ShellMaterialStrainLinearized& strain,
-                  Precision*                           state,
+                  const Precision*                     old_state,
+                  Precision*                           new_state,
                   ShellMaterialStressCauchy&            stress,
                   Mat5&                                 tangent) const override;
 
     // Finite-strain shell response returning PK2 components and their constant
     // derivative with respect to five-component Green-Lagrange shell strain.
     void evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                  Precision*                              state,
+                  const Precision*                        old_state,
+                  Precision*                              new_state,
                   ShellMaterialStressPK2&                 stress,
                   Mat5&                                   tangent) const override;
 

--- a/src/material/isotropic_elasticity.cpp
+++ b/src/material/isotropic_elasticity.cpp
@@ -129,15 +129,18 @@ Mat6 IsotropicElasticity::volume_tangent() const {
  * Evaluates linearized axial Cauchy stress from infinitesimal strain.
  *
  * @param strain Infinitesimal axial strain.
- * @param state Unused state row; isotropic Hooke elasticity is stateless.
+ * @param old_state Unused input state row; isotropic Hooke elasticity is stateless.
+ * @param new_state Unused output state row.
  * @param stress Axial Cauchy stress.
  * @param tangent Constant derivative `d sigma/d epsilon = E`.
  */
 void IsotropicElasticity::evaluate(const AxialStrainLinearized& strain,
-                                   Precision*                   state,
+                                   const Precision*             old_state,
+                                   Precision*                   new_state,
                                    AxialStressCauchy&           stress,
                                    Precision&                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = youngs;
     stress.value() = tangent * strain.value();
 }
@@ -146,15 +149,18 @@ void IsotropicElasticity::evaluate(const AxialStrainLinearized& strain,
  * Evaluates axial PK2 stress work-conjugate to Green-Lagrange strain.
  *
  * @param strain Axial Green-Lagrange strain.
- * @param state Unused state row; isotropic Hooke elasticity is stateless.
+ * @param old_state Unused input state row; isotropic Hooke elasticity is stateless.
+ * @param new_state Unused output state row.
  * @param stress Axial second Piola-Kirchhoff stress.
  * @param tangent Constant material derivative `dS/dE = E`.
  */
 void IsotropicElasticity::evaluate(const AxialStrainGreenLagrange& strain,
-                                   Precision*                      state,
+                                   const Precision*                old_state,
+                                   Precision*                      new_state,
                                    AxialStressPK2&                 stress,
                                    Precision&                      tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = youngs;
     stress.value() = tangent * strain.value();
 }
@@ -163,15 +169,18 @@ void IsotropicElasticity::evaluate(const AxialStrainGreenLagrange& strain,
  * Evaluates linearized three-dimensional Cauchy stress in material coordinates.
  *
  * @param strain Infinitesimal engineering strain vector.
- * @param state Unused state row; isotropic Hooke elasticity is stateless.
+ * @param old_state Unused input state row; isotropic Hooke elasticity is stateless.
+ * @param new_state Unused output state row.
  * @param stress Cauchy stress in engineering-Voigt ordering.
  * @param tangent Constant isotropic three-dimensional tangent.
  */
 void IsotropicElasticity::evaluate(const VolumeStrainLinearized& strain,
-                                   Precision*                    state,
+                                   const Precision*              old_state,
+                                   Precision*                    new_state,
                                    VolumeStressCauchy&           stress,
                                    Mat6&                         tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = volume_tangent();
     stress.voigt() = tangent * strain.voigt();
 }
@@ -180,15 +189,18 @@ void IsotropicElasticity::evaluate(const VolumeStrainLinearized& strain,
  * Evaluates three-dimensional PK2 stress from Green-Lagrange strain.
  *
  * @param strain Green-Lagrange engineering strain vector.
- * @param state Unused state row; isotropic Hooke elasticity is stateless.
+ * @param old_state Unused input state row; isotropic Hooke elasticity is stateless.
+ * @param new_state Unused output state row.
  * @param stress Second Piola-Kirchhoff stress in material coordinates.
  * @param tangent Constant material derivative `dS/dE`.
  */
 void IsotropicElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
-                                   Precision*                       state,
+                                   const Precision*                 old_state,
+                                   Precision*                       new_state,
                                    VolumeStressPK2&                 stress,
                                    Mat6&                            tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = volume_tangent();
     stress.voigt() = tangent * strain.voigt();
 }
@@ -197,15 +209,18 @@ void IsotropicElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
  * Evaluates linearized five-component shell Cauchy stress under plane stress.
  *
  * @param strain Shell material strain ordered `[11,22,12,13,23]`.
- * @param state Unused state row; isotropic Hooke elasticity is stateless.
+ * @param old_state Unused input state row; isotropic Hooke elasticity is stateless.
+ * @param new_state Unused output state row.
  * @param stress Shell Cauchy stress in the same material ordering.
  * @param tangent Constant reduced shell tangent.
  */
 void IsotropicElasticity::evaluate(const ShellMaterialStrainLinearized& strain,
-                                   Precision*                           state,
+                                   const Precision*                     old_state,
+                                   Precision*                           new_state,
                                    ShellMaterialStressCauchy&            stress,
                                    Mat5&                                 tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent         = shell_material_tangent();
     stress.values() = tangent * strain.values();
 }
@@ -214,15 +229,18 @@ void IsotropicElasticity::evaluate(const ShellMaterialStrainLinearized& strain,
  * Evaluates five-component shell PK2 stress from Green-Lagrange strain.
  *
  * @param strain Shell Green-Lagrange material strain.
- * @param state Unused state row; isotropic Hooke elasticity is stateless.
+ * @param old_state Unused input state row; isotropic Hooke elasticity is stateless.
+ * @param new_state Unused output state row.
  * @param stress Shell second Piola-Kirchhoff stress.
  * @param tangent Constant reduced material derivative.
  */
 void IsotropicElasticity::evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                                   Precision*                              state,
+                                   const Precision*                        old_state,
+                                   Precision*                              new_state,
                                    ShellMaterialStressPK2&                 stress,
                                    Mat5&                                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent         = shell_material_tangent();
     stress.values() = tangent * strain.values();
 }

--- a/src/material/isotropic_elasticity.h
+++ b/src/material/isotropic_elasticity.h
@@ -27,9 +27,8 @@ namespace fem::material {
  * an in-plane plane-stress block and two transverse shear components. All
  * tangents are expressed in the material basis supplied by the owning section.
  *
- * The model has no history variables. The state pointer accepted through the
- * common elasticity interface is deliberately left unchanged by every
- * evaluation.
+ * The model has no history variables. The state pointers accepted through the
+ * common elasticity interface are deliberately unused by every evaluation.
  */
 struct IsotropicElasticity : Elasticity {
     // Independent elastic constants and derived shear modulus
@@ -54,42 +53,48 @@ struct IsotropicElasticity : Elasticity {
     // Linearized axial Hooke response: sigma = E epsilon and d sigma/d epsilon = E.
     // The supplied state row is valid but unchanged because this law is stateless.
     void evaluate(const AxialStrainLinearized& strain,
-                  Precision*                   state,
+                  const Precision*             old_state,
+                  Precision*                   new_state,
                   AxialStressCauchy&           stress,
                   Precision&                   tangent) const override;
 
     // Total-Lagrangian axial Hooke response: S = E E_GL. PK2 stress and
     // Green-Lagrange strain are work-conjugate in the reference material axis.
     void evaluate(const AxialStrainGreenLagrange& strain,
-                  Precision*                      state,
+                  const Precision*                old_state,
+                  Precision*                      new_state,
                   AxialStressPK2&                 stress,
                   Precision&                      tangent) const override;
 
     // Linearized three-dimensional response in material coordinates. The
     // constant isotropic six-by-six tangent maps engineering strain to Cauchy stress.
     void evaluate(const VolumeStrainLinearized& strain,
-                  Precision*                    state,
+                  const Precision*              old_state,
+                  Precision*                    new_state,
                   VolumeStressCauchy&           stress,
                   Mat6&                         tangent) const override;
 
     // Finite-strain material response using the same constant Hooke operator.
     // Input is Green-Lagrange strain and output is second Piola-Kirchhoff stress.
     void evaluate(const VolumeStrainGreenLagrange& strain,
-                  Precision*                       state,
+                  const Precision*                 old_state,
+                  Precision*                       new_state,
                   VolumeStressPK2&                 stress,
                   Mat6&                            tangent) const override;
 
     // Linearized five-component shell response with an in-plane plane-stress
     // block and transverse shear moduli. Output stress is Cauchy stress.
     void evaluate(const ShellMaterialStrainLinearized& strain,
-                  Precision*                           state,
+                  const Precision*                     old_state,
+                  Precision*                           new_state,
                   ShellMaterialStressCauchy&            stress,
                   Mat5&                                 tangent) const override;
 
     // Green-Lagrange five-component shell response with PK2 output. The same
     // constant reduced tangent is used and the material state remains unchanged.
     void evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                  Precision*                              state,
+                  const Precision*                        old_state,
+                  Precision*                              new_state,
                   ShellMaterialStressPK2&                 stress,
                   Mat5&                                   tangent) const override;
 

--- a/src/material/neo_hooke_elasticity.cpp
+++ b/src/material/neo_hooke_elasticity.cpp
@@ -9,7 +9,7 @@
  * the full material tangent.
  *
  * All constitutive calls are state-neutral because the Neo-Hookean law contains
- * no history variables; the state pointer is accepted only through the common
+ * no history variables; the state pointers are accepted only through the common
  * `Elasticity` interface.
  *
  * @see NeoHookeElasticity
@@ -132,10 +132,12 @@ Mat5 NeoHookeElasticity::linear_shell_tangent() const {
 }
 
 void NeoHookeElasticity::evaluate(const AxialStrainLinearized& strain,
-                                  Precision*                   state,
+                                  const Precision*             old_state,
+                                  Precision*                   new_state,
                                   AxialStressCauchy&           stress,
                                   Precision&                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
 
     const Precision youngs = Precision(9) * bulk * mu / (Precision(3) * bulk + mu);
     tangent        = youngs;
@@ -154,20 +156,23 @@ void NeoHookeElasticity::evaluate(const AxialStrainLinearized& strain,
  *
  * The logarithmic lateral variable keeps the transverse stretch positive. A
  * non-positive axial metric or a failed local plane-stress solve is reported as
- * a material error. The Neo-Hookean model is stateless, so `state` is not
- * modified.
+ * a material error. The Neo-Hookean model is stateless, so neither state row is
+ * used.
  *
  * @param strain Axial Green-Lagrange strain in the material direction.
- * @param state Unused material-point state row retained by the common interface.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Axial second Piola-Kirchhoff stress.
  * @param tangent Consistent derivative of axial PK2 stress with respect to the
  *                axial Green-Lagrange strain.
  */
 void NeoHookeElasticity::evaluate(const AxialStrainGreenLagrange& strain,
-                                  Precision*                      state,
+                                  const Precision*                old_state,
+                                  Precision*                      new_state,
                                   AxialStressPK2&                 stress,
                                   Precision&                      tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
 
     const Precision c       = Precision(1) + Precision(2) * strain.value();
     const Precision poisson = (Precision(3) * bulk - Precision(2) * mu)
@@ -232,10 +237,12 @@ void NeoHookeElasticity::evaluate(const AxialStrainGreenLagrange& strain,
 }
 
 void NeoHookeElasticity::evaluate(const VolumeStrainLinearized& strain,
-                                  Precision*                    state,
+                                  const Precision*              old_state,
+                                  Precision*                    new_state,
                                   VolumeStressCauchy&           stress,
                                   Mat6&                         tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
 
     tangent        = linear_tangent();
     stress.voigt() = tangent * strain.voigt();
@@ -250,15 +257,18 @@ void NeoHookeElasticity::evaluate(const VolumeStrainLinearized& strain,
  * reduction or stress transformation is applied here.
  *
  * @param strain Green-Lagrange strain in the material basis.
- * @param state Unused material-point state row retained by the common interface.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Second Piola-Kirchhoff stress in the material basis.
  * @param tangent Consistent derivative `dS/dE`.
  */
 void NeoHookeElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
-                                  Precision*                       state,
+                                  const Precision*                 old_state,
+                                  Precision*                       new_state,
                                   VolumeStressPK2&                 stress,
                                   Mat6&                            tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
 
     const Mat3 C = Mat3::Identity() + Precision(2) * strain.tensor();
     Mat3       full_stress;
@@ -268,10 +278,12 @@ void NeoHookeElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
 }
 
 void NeoHookeElasticity::evaluate(const ShellMaterialStrainLinearized& strain,
-                                  Precision*                           state,
+                                  const Precision*                     old_state,
+                                  Precision*                           new_state,
                                   ShellMaterialStressCauchy&            stress,
                                   Mat5&                                 tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
 
     tangent         = linear_shell_tangent();
     stress.values() = tangent * strain.values();
@@ -289,18 +301,21 @@ void NeoHookeElasticity::evaluate(const ShellMaterialStrainLinearized& strain,
  * After convergence, the shell PK2 components are extracted in the ordering
  * `[S11,S22,S12,S13,S23]`. The corresponding five-by-five tangent is the Schur
  * complement of the eliminated thickness component and is therefore consistent
- * with the local plane-stress solve. The state row remains unchanged.
+ * with the local plane-stress solve. Both state rows remain unused.
  *
  * @param strain Green-Lagrange shell material strain.
- * @param state Unused material-point state row retained by the common interface.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Plane-stress shell PK2 components.
  * @param tangent Condensed consistent shell material tangent.
  */
 void NeoHookeElasticity::evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                                  Precision*                              state,
+                                  const Precision*                        old_state,
+                                  Precision*                              new_state,
                                   ShellMaterialStressPK2&                 stress,
                                   Mat5&                                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
 
     Mat3 C = Mat3::Identity();
     C(0, 0) = Precision(1) + Precision(2) * strain.values()(0);

--- a/src/material/neo_hooke_elasticity.h
+++ b/src/material/neo_hooke_elasticity.h
@@ -62,7 +62,8 @@ struct NeoHookeElasticity : Elasticity {
     // Infinitesimal axial response using the Young's modulus implied by the
     // Neo-Hookean parameters. Stress is Cauchy stress and state is unchanged.
     void evaluate(const AxialStrainLinearized& strain,
-                  Precision*                   state,
+                  const Precision*             old_state,
+                  Precision*                   new_state,
                   AxialStressCauchy&           stress,
                   Precision&                   tangent) const override;
 
@@ -70,28 +71,32 @@ struct NeoHookeElasticity : Elasticity {
     // A local solve enforces zero lateral PK2 stress and the returned dS/dE is
     // condensed consistently from the converged three-dimensional tangent.
     void evaluate(const AxialStrainGreenLagrange& strain,
-                  Precision*                      state,
+                  const Precision*                old_state,
+                  Precision*                      new_state,
                   AxialStressPK2&                 stress,
                   Precision&                      tangent) const override;
 
     // Infinitesimal three-dimensional response using the linearization of the
     // finite-strain potential at C = I. Output is Cauchy stress in material axes.
     void evaluate(const VolumeStrainLinearized& strain,
-                  Precision*                    state,
+                  const Precision*              old_state,
+                  Precision*                    new_state,
                   VolumeStressCauchy&           stress,
                   Mat6&                         tangent) const override;
 
     // Full finite-strain response. Green-Lagrange strain is mapped to C = I+2E;
     // output is PK2 stress and the consistent material tangent dS/dE.
     void evaluate(const VolumeStrainGreenLagrange& strain,
-                  Precision*                       state,
+                  const Precision*                 old_state,
+                  Precision*                       new_state,
                   VolumeStressPK2&                 stress,
                   Mat6&                            tangent) const override;
 
     // Infinitesimal shell response from the linearized plane-stress and
     // transverse-shear tangent implied by the three-dimensional parameters.
     void evaluate(const ShellMaterialStrainLinearized& strain,
-                  Precision*                           state,
+                  const Precision*                     old_state,
+                  Precision*                           new_state,
                   ShellMaterialStressCauchy&            stress,
                   Mat5&                                 tangent) const override;
 
@@ -99,7 +104,8 @@ struct NeoHookeElasticity : Elasticity {
     // the five-component PK2 stress and tangent are condensed at convergence.
     // The solve is local and state-neutral.
     void evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                  Precision*                              state,
+                  const Precision*                        old_state,
+                  Precision*                              new_state,
                   ShellMaterialStressPK2&                 stress,
                   Mat5&                                   tangent) const override;
 

--- a/src/material/orthotropic_elasticity.cpp
+++ b/src/material/orthotropic_elasticity.cpp
@@ -144,15 +144,18 @@ Mat6 OrthotropicElasticity::volume_tangent() const {
  * Evaluates linearized orthotropic Cauchy stress in material coordinates.
  *
  * @param strain Infinitesimal engineering strain vector.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Cauchy stress in engineering-Voigt ordering.
  * @param tangent Constant orthotropic volume tangent.
  */
 void OrthotropicElasticity::evaluate(const VolumeStrainLinearized& strain,
-                                     Precision*                    state,
+                                     const Precision*              old_state,
+                                     Precision*                    new_state,
                                      VolumeStressCauchy&           stress,
                                      Mat6&                         tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = volume_tangent();
     stress.voigt() = tangent * strain.voigt();
 }
@@ -161,15 +164,18 @@ void OrthotropicElasticity::evaluate(const VolumeStrainLinearized& strain,
  * Evaluates orthotropic PK2 stress from Green-Lagrange strain.
  *
  * @param strain Green-Lagrange engineering strain vector.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Second Piola-Kirchhoff stress in material coordinates.
  * @param tangent Constant material derivative `dS/dE`.
  */
 void OrthotropicElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
-                                     Precision*                       state,
+                                     const Precision*                 old_state,
+                                     Precision*                       new_state,
                                      VolumeStressPK2&                 stress,
                                      Mat6&                            tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent        = volume_tangent();
     stress.voigt() = tangent * strain.voigt();
 }
@@ -178,15 +184,18 @@ void OrthotropicElasticity::evaluate(const VolumeStrainGreenLagrange& strain,
  * Evaluates linearized orthotropic shell Cauchy stress under plane stress.
  *
  * @param strain Five-component shell material strain.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Shell Cauchy stress in material ordering.
  * @param tangent Constant reduced orthotropic shell tangent.
  */
 void OrthotropicElasticity::evaluate(const ShellMaterialStrainLinearized& strain,
-                                     Precision*                           state,
+                                     const Precision*                     old_state,
+                                     Precision*                           new_state,
                                      ShellMaterialStressCauchy&            stress,
                                      Mat5&                                 tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent         = shell_material_tangent();
     stress.values() = tangent * strain.values();
 }
@@ -195,15 +204,18 @@ void OrthotropicElasticity::evaluate(const ShellMaterialStrainLinearized& strain
  * Evaluates orthotropic shell PK2 stress from Green-Lagrange strain.
  *
  * @param strain Five-component Green-Lagrange material strain.
- * @param state Unused material-point state row.
+ * @param old_state Unused input material-point state row.
+ * @param new_state Unused output material-point state row.
  * @param stress Shell second Piola-Kirchhoff stress.
  * @param tangent Constant reduced material derivative.
  */
 void OrthotropicElasticity::evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                                     Precision*                              state,
+                                     const Precision*                        old_state,
+                                     Precision*                              new_state,
                                      ShellMaterialStressPK2&                 stress,
                                      Mat5&                                   tangent) const {
-    (void) state;
+    (void) old_state;
+    (void) new_state;
     tangent         = shell_material_tangent();
     stress.values() = tangent * strain.values();
 }

--- a/src/material/orthotropic_elasticity.h
+++ b/src/material/orthotropic_elasticity.h
@@ -79,28 +79,32 @@ struct OrthotropicElasticity : Elasticity {
     // Linearized three-dimensional orthotropic response in material axes.
     // tangent maps engineering strain to Cauchy stress and state is unchanged.
     void evaluate(const VolumeStrainLinearized& strain,
-                  Precision*                    state,
+                  const Precision*              old_state,
+                  Precision*                    new_state,
                   VolumeStressCauchy&           stress,
                   Mat6&                         tangent) const override;
 
     // Total-Lagrangian orthotropic response using the same constant material
     // operator, interpreted as dS/dE for PK2 stress and Green-Lagrange strain.
     void evaluate(const VolumeStrainGreenLagrange& strain,
-                  Precision*                       state,
+                  const Precision*                 old_state,
+                  Precision*                       new_state,
                   VolumeStressPK2&                 stress,
                   Mat6&                            tangent) const override;
 
     // Linearized shell response in the material basis. In-plane terms use the
     // orthotropic plane-stress reduction; 13 and 23 shear use G13 and G23.
     void evaluate(const ShellMaterialStrainLinearized& strain,
-                  Precision*                           state,
+                  const Precision*                     old_state,
+                  Precision*                           new_state,
                   ShellMaterialStressCauchy&            stress,
                   Mat5&                                 tangent) const override;
 
     // Finite-strain shell response returning PK2 components work-conjugate to
     // the five supplied Green-Lagrange strain components. State remains unchanged.
     void evaluate(const ShellMaterialStrainGreenLagrange& strain,
-                  Precision*                              state,
+                  const Precision*                        old_state,
+                  Precision*                              new_state,
                   ShellMaterialStressPK2&                 stress,
                   Mat5&                                   tangent) const override;
 

--- a/src/model/model_data.cpp
+++ b/src/model/model_data.cpp
@@ -138,11 +138,16 @@ void ModelData::initialize_element_enumeration() {
     (*element_ip_offsets)(element_count)    = static_cast<Precision>(ip_offset);
     (*element_mp_offsets)(element_count)    = static_cast<Precision>(mp_offset);
 
-    // Provide a zeroed default state row for every enumerated material point
+    // Provide separate zeroed input and output state rows for every enumerated
+    // material point. Constitutive evaluations may never overwrite their input.
     if (mp_offset > 0) {
-        material_state = std::make_shared<Field>(
-            "MATERIAL_STATE", FieldDomain::ELEMENT_MP, mp_offset, 1);
-        material_state->set_zero();
+        material_state_old = std::make_shared<Field>(
+            "MATERIAL_STATE_OLD", FieldDomain::ELEMENT_MP, mp_offset, 1);
+        material_state_new = std::make_shared<Field>(
+            "MATERIAL_STATE_NEW", FieldDomain::ELEMENT_MP, mp_offset, 1);
+
+        material_state_old->set_zero();
+        material_state_new->set_zero();
     }
 }
 

--- a/src/model/model_data.h
+++ b/src/model/model_data.h
@@ -133,11 +133,15 @@ struct ModelData {
     Field::Ptr positions_reference         = nullptr;
     Field::Ptr element_stiffness_scale     = nullptr;
     Field::Ptr material_orientation        = nullptr;
-    Field::Ptr material_state              = nullptr;
     Field::Ptr shell_element_nodal_normals = nullptr;
     Field::Ptr element_nodal_offsets       = nullptr;
     Field::Ptr element_ip_offsets          = nullptr;
     Field::Ptr element_mp_offsets          = nullptr;
+
+    // Constitutive history read by the current evaluation and the separate
+    // output history produced by that evaluation.
+    Field::Ptr material_state_old = nullptr;
+    Field::Ptr material_state_new = nullptr;
 
     // Global assembly regions materialized from the compiled instances. Every
     // collection owns an aggregate *ALL region that receives all dense entities.

--- a/src/model/shell/frt_shell_assembly.inl
+++ b/src/model/shell/frt_shell_assembly.inl
@@ -67,9 +67,9 @@ void FRTShell<N>::load_ip_resultants(
  * matrices and therefore can consume a material tangent.
  *
  * Each in-plane integration point owns a contiguous block of section material
- * points in `ModelData::material_state`. The first row and the global field
- * component count are passed as pointer and stride so integrated sections can
- * update their through-thickness histories directly in place.
+ * points in the old/new `ModelData` state fields. The first rows and global
+ * component count are passed as pointers and stride so integrated sections can
+ * write their through-thickness histories without changing their input.
  *
  * @param data Active thread-local evaluation view.
  */
@@ -83,7 +83,7 @@ void FRTShell<N>::compute_material_resultants(EvaluationData& data) const {
     ShellSection*   section = shell_section();
     const Precision scale   = topology_stiffness_scale();
     const auto&     points  = reference_data().ip_points;
-    const Index     state_stride = this->_model_data->material_state->components;
+    const Index     state_stride = this->_model_data->material_state_old->components;
 
     // Evaluate one generalized section response for every shell integration point
     for (Index ip = 0; ip < static_cast<Index>(points.size()); ++ip) {
@@ -95,9 +95,11 @@ void FRTShell<N>::compute_material_resultants(EvaluationData& data) const {
         ShellStressResultants  resultants;
         Mat8                   tangent;
 
-        // Address the first through-thickness state row of this in-plane point;
-        // the section advances further rows using state_stride
-        Precision*             state = &(*this->_model_data->material_state)(this->mp_index(ip, 0), 0);
+        // Address the first through-thickness input/output rows of this in-plane
+        // point; the section advances further rows using state_stride
+        const Index      state_row = this->mp_index(ip, 0);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         // Supply the same pointwise global basis used by the strain transformation
         Mat3 basis = point.basis;
@@ -106,7 +108,8 @@ void FRTShell<N>::compute_material_resultants(EvaluationData& data) const {
             reference_position(point.r, point.s),
             basis,
             strain,
-            state,
+            old_state,
+            new_state,
             state_stride,
             true,
             resultants,

--- a/src/model/shell/frt_shell_kinematics.inl
+++ b/src/model/shell/frt_shell_kinematics.inl
@@ -649,7 +649,7 @@ typename FRTShell<N>::EvaluationData FRTShell<N>::init_evaluation(
             constexpr Index gamma_12 =
                 static_cast<Index>(Component::GammaXY);
 
-            const Index state_stride = this->_model_data->material_state->components;
+            const Index state_stride = this->_model_data->material_state_old->components;
 
             for (Index ip = 0; ip < static_cast<Index>(reference_data_->ip_points.size()); ++ip) {
                 ReferencePoint& point = reference_data_->ip_points[static_cast<std::size_t>(ip)];
@@ -657,14 +657,18 @@ typename FRTShell<N>::EvaluationData FRTShell<N>::init_evaluation(
                 ShellStressResultants  zero_resultants;
                 Mat8                   H0;
                 Mat3                   basis = point.basis;
-                Precision*             material_state =
-                    &(*this->_model_data->material_state)(this->mp_index(ip, 0), 0);
+                const Index      state_row = this->mp_index(ip, 0);
+                const Precision* old_material_state =
+                    &(*this->_model_data->material_state_old)(state_row, 0);
+                Precision* new_material_state =
+                    &(*this->_model_data->material_state_new)(state_row, 0);
 
                 shell_section()->evaluate(
                     reference_position(point.r, point.s),
                     basis,
                     zero_strain,
-                    material_state,
+                    old_material_state,
+                    new_material_state,
                     state_stride,
                     false,
                     zero_resultants,

--- a/src/model/shell/frt_shell_output.inl
+++ b/src/model/shell/frt_shell_output.inl
@@ -130,15 +130,18 @@ typename FRTShell<N>::Vec8 FRTShell<N>::generalized_resultant_at(
         }
     }
 
-    // Address the first through-thickness material state at the selected shell IP
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip, 0), 0);
+    // Address the first through-thickness state rows at the selected shell IP
+    const Index      state_row = this->mp_index(state_ip, 0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
     shell_section()->evaluate(
         reference_position(r, s),
         reference_basis_global(r, s),
         strain,
-        state,
-        this->_model_data->material_state->components,
+        old_state,
+        new_state,
+        this->_model_data->material_state_old->components,
         true,
         resultants,
         tangent
@@ -298,15 +301,18 @@ void FRTShell<N>::physical_stress_strain_at(
         }
     }
 
-    // Pass the first row of the selected through-thickness material-state block
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip, 0), 0);
+    // Pass the first input/output rows of the selected material-state block
+    const Index      state_row = this->mp_index(state_ip, 0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
     const VolumeStressCauchy cauchy_stress = this->get_section()->evaluate_output_stress(
         reference_position(r, s),
         reference_basis,
         ShellGeneralizedStrain(generalized_strain),
-        state,
-        this->_model_data->material_state->components,
+        old_state,
+        new_state,
+        this->_model_data->material_state_old->components,
         z,
         nonlinear,
         deformation_gradient
@@ -518,16 +524,20 @@ bool FRTShell<N>::compute_shell_section_forces(Field&       resultants,
             }
         }
 
-        // Pass the selected state block through the common output-resultant path
-        Precision* material_state =
-            &(*this->_model_data->material_state)(this->mp_index(state_ip, 0), 0);
+        // Pass the selected input/output blocks through the common output path
+        const Index      state_row = this->mp_index(state_ip, 0);
+        const Precision* old_material_state =
+            &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision* new_material_state =
+            &(*this->_model_data->material_state_new)(state_row, 0);
 
         const ShellStressResultants output_resultants = section->evaluate_output_resultants(
             reference_position(r, s),
             reference_basis_global(r, s),
             strain,
-            material_state,
-            this->_model_data->material_state->components,
+            old_material_state,
+            new_material_state,
+            this->_model_data->material_state_old->components,
             true
         );
         const Vec8 values = scale * output_resultants.values();

--- a/src/model/shell/frt_shell_reference.inl
+++ b/src/model/shell/frt_shell_reference.inl
@@ -485,15 +485,18 @@ typename FRTShell<N>::Mat8 FRTShell<N>::resultant_stiffness(
         }
     }
 
-    // Pass the first through-thickness row and common row stride to the section
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip, 0), 0);
+    // Pass the first through-thickness input/output rows and common row stride
+    const Index      state_row = this->mp_index(state_ip, 0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
     shell_section()->evaluate(
         reference_position(r, s),
         reference_basis_global(r, s),
         zero_strain,
-        state,
-        this->_model_data->material_state->components,
+        old_state,
+        new_state,
+        this->_model_data->material_state_old->components,
         false,
         zero_resultants,
         H

--- a/src/model/shell/qspt.cpp
+++ b/src/model/shell/qspt.cpp
@@ -5,7 +5,7 @@
  * QSPT derives its effective in-plane shear stiffness from the assigned shell
  * section and uses the resulting scalar flexibility for its shear-flow element
  * formulation. Section evaluation receives the globally enumerated material-
- * point state directly from `ModelData::material_state`.
+ * point state directly from the old/new `ModelData` state fields.
  *
  * @see QSPT
  *
@@ -157,14 +157,17 @@ Precision QSPT::effective_shear_modulus() {
     ShellStressResultants  zero_resultants;
     Mat8                   tangent;
 
-    // Evaluate the zero-strain section tangent on the element material-state row
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(0, 0), 0);
+    // Evaluate the zero-strain section tangent on the element state rows
+    const Index      state_row = this->mp_index(0, 0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
     this->get_section()->evaluate(
         center,
         shell_basis,
         zero_strain,
-        state,
-        this->_model_data->material_state->components,
+        old_state,
+        new_state,
+        this->_model_data->material_state_old->components,
         false,
         zero_resultants,
         tangent

--- a/src/model/shell/shell_simple.h
+++ b/src/model/shell/shell_simple.h
@@ -456,14 +456,17 @@ struct DefaultShellElement : public ShellElement<N> {
                 ShellStressResultants  zero_resultants;
                 Mat8                   tangent;
 
-                // Address the first through-thickness state row at this ABD point
-                Precision* state = &(*this->_model_data->material_state)(this->mp_index(ip_abd++, 0), 0);
+                // Address the first through-thickness state rows at this ABD point
+                const Index      state_row = this->mp_index(ip_abd++, 0);
+                const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+                Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
                 section->evaluate(
                     this->reference_point(r, s),
                     shell_basis,
                     zero_strain,
-                    state,
-                    this->_model_data->material_state->components,
+                    old_state,
+                    new_state,
+                    this->_model_data->material_state_old->components,
                     false,
                     zero_resultants,
                     tangent
@@ -496,14 +499,17 @@ struct DefaultShellElement : public ShellElement<N> {
                 ShellStressResultants  zero_resultants;
                 Mat8                   tangent;
 
-                // Address the first through-thickness state row at this shear point
-                Precision* state = &(*this->_model_data->material_state)(this->mp_index(ip_shear++, 0), 0);
+                // Address the first through-thickness state rows at this shear point
+                const Index      state_row = this->mp_index(ip_shear++, 0);
+                const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+                Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
                 section->evaluate(
                     this->reference_point(r, s),
                     shell_basis,
                     zero_strain,
-                    state,
-                    this->_model_data->material_state->components,
+                    old_state,
+                    new_state,
+                    this->_model_data->material_state_old->components,
                     false,
                     zero_resultants,
                     tangent
@@ -873,15 +879,18 @@ struct DefaultShellElement : public ShellElement<N> {
             }
         }
 
-        // Pass the first through-thickness state row and common field stride
-        Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip, 0), 0);
+        // Pass the first through-thickness input/output rows and common stride
+        const Index      state_row = this->mp_index(state_ip, 0);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         VolumeStressCauchy stress = this->get_section()->evaluate_output_stress(
             reference_point(r, s),
             shell_basis,
             generalized_strain,
-            state,
-            this->_model_data->material_state->components,
+            old_state,
+            new_state,
+            this->_model_data->material_state_old->components,
             z,
             false
         );
@@ -986,15 +995,18 @@ struct DefaultShellElement : public ShellElement<N> {
                 }
             }
 
-            // Pass the selected through-thickness state block to the section
-            Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip, 0), 0);
+            // Pass the selected through-thickness input/output blocks to the section
+            const Index      state_row = this->mp_index(state_ip, 0);
+            const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+            Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
             const ShellStressResultants output_resultants = this->get_section()->evaluate_output_resultants(
                 reference_point(r, s),
                 shell_basis,
                 generalized_strain,
-                state,
-                this->_model_data->material_state->components,
+                old_state,
+                new_state,
+                this->_model_data->material_state_old->components,
                 false
             );
 
@@ -1129,15 +1141,18 @@ struct DefaultShellElement : public ShellElement<N> {
 
             ShellGeneralizedStrain generalized_strain;
             generalized_strain.values().template segment<3>(membrane_start) = eps_element;
-            ShellStressResultants  generalized_resultants;
-            Mat8                   tangent;
-            Precision*             state = &(*this->_model_data->material_state)(this->mp_index(ip, 0), 0);
+            ShellStressResultants generalized_resultants;
+            Mat8                  tangent;
+            const Index      state_row = this->mp_index(ip, 0);
+            const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+            Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
             this->get_section()->evaluate(
                 reference_point(r, s),
                 shell_basis,
                 generalized_strain,
-                state,
-                this->_model_data->material_state->components,
+                old_state,
+                new_state,
+                this->_model_data->material_state_old->components,
                 false,
                 generalized_resultants,
                 tangent

--- a/src/model/solid/c3d8r.cpp
+++ b/src/model/solid/c3d8r.cpp
@@ -14,7 +14,6 @@
 #include "c3d8r.h"
 
 #include <cmath>
-#include <vector>
 
 namespace fem::model {
 
@@ -130,30 +129,18 @@ C3D8R::GradientMatrix C3D8R::mean_reference_gradient(Precision& reference_volume
  * physical material-point history.
  *
  * The hourglass modulus is an auxiliary stabilization quantity rather than a
- * constitutive update of the current continuum state. The complete active state
- * row is therefore saved, the zero-strain tangent is evaluated through the same
- * material API, and the row is restored immediately afterwards.
+ * constitutive update of the current continuum state. The zero-strain tangent
+ * therefore reads the immutable old row and writes only the separate new row.
  *
  * @return Mean material shear diagonal `(C44 + C55 + C66) / 3`.
  */
 Precision C3D8R::hourglass_material_scale() {
-    // Preserve the complete physical center-point history around the auxiliary
-    // zero-strain tangent evaluation
-    const Index state_row = this->mp_index(0);
-    Field&      state_field = *this->_model_data->material_state;
+    const Index      state_row = this->mp_index(0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
-    std::vector<Precision> saved_state(static_cast<std::size_t>(state_field.components));
-    for (Index component = 0; component < state_field.components; ++component) {
-        saved_state[static_cast<std::size_t>(component)] = state_field(state_row, component);
-    }
-
-    Precision* state = &state_field(state_row, 0);
     const Mat6 material_tangent = material_tangent_reference(
-        Precision(0), Precision(0), Precision(0), state);
-
-    for (Index component = 0; component < state_field.components; ++component) {
-        state_field(state_row, component) = saved_state[static_cast<std::size_t>(component)];
-    }
+        Precision(0), Precision(0), Precision(0), old_state, new_state);
 
     const Precision shear_scale =
         (material_tangent(3, 3) + material_tangent(4, 4) + material_tangent(5, 5)) / Precision(3);

--- a/src/model/solid/element_solid.h
+++ b/src/model/solid/element_solid.h
@@ -7,9 +7,9 @@
  * assembly used by the concrete C3D solid topologies.
  *
  * Every constitutive integration point is associated with one globally
- * enumerated material-point row. The element addresses that row directly in
- * `ModelData::material_state` and passes its first component to the section and
- * material model without additional state access abstractions.
+ * enumerated material-point row. The element addresses corresponding rows in
+ * `ModelData::material_state_old` and `material_state_new` and passes their
+ * first components to the section and material model.
  *
  * @author Finn Eggers
  * @date 07.08.2026
@@ -37,9 +37,8 @@ namespace fem::model {
  * Concrete solid elements provide topology-specific interpolation and
  * quadrature. The base implements geometry transformations, constitutive
  * evaluation and common linear/nonlinear assembly. In nonlinear tangent
- * assembly each material point is evaluated exactly once so an in-place
- * constitutive history state cannot advance twice within one residual/tangent
- * evaluation.
+ * assembly each material point is evaluated exactly once. Constitutive history
+ * is read from the old row and written to the separate new row.
  */
 template<Index N>
 struct SolidElement : StructuralElement, ThermalElement{
@@ -91,19 +90,19 @@ public:
     Vec3      material_position_reference(Precision r, Precision s, Precision t);
 
     // Evaluate the zero-Green-Lagrange material tangent at one natural point.
-    // state is the caller-selected material-point row and may be touched by a
-    // history-dependent material, so auxiliary callers must preserve it when
-    // the query is intended to be state-neutral.
-    Mat6 material_tangent_reference(Precision r, Precision s, Precision t, Precision* state);
+    // The caller selects immutable input and mutable output state rows.
+    Mat6 material_tangent_reference(Precision r, Precision s, Precision t,
+                                    const Precision* old_state, Precision* new_state);
 
     // Evaluate linearized Cauchy stress and tangent in global coordinates. The
-    // active state row is forwarded directly through SolidSection, after which
-    // optional element stiffness scaling is applied to stress and tangent.
+    // selected old/new state rows are forwarded directly through SolidSection,
+    // after which optional element stiffness scaling is applied.
     void evaluate_material(Precision                     r,
                            Precision                     s,
                            Precision                     t,
                            const VolumeStrainLinearized& global_strain,
-                           Precision*                    state,
+                           const Precision*              old_state,
+                           Precision*                    new_state,
                            VolumeStressCauchy&           global_stress,
                            Mat6&                         global_tangent);
 
@@ -113,7 +112,8 @@ public:
                            Precision                        s,
                            Precision                        t,
                            const VolumeStrainGreenLagrange& global_strain,
-                           Precision*                       state,
+                           const Precision*                 old_state,
+                           Precision*                       new_state,
                            VolumeStressPK2&                 global_stress,
                            Mat6&                            global_tangent);
 
@@ -165,9 +165,9 @@ public:
     );
 
     // Element matrices and nonlinear tangent assembly. stiffness_tangent()
-    // performs exactly one in-place constitutive update per quadrature point and
-    // reuses the resulting PK2 stress for material tangent, geometric tangent,
-    // stored integration-point state and matching internal force.
+    // performs exactly one constitutive update per quadrature point and reuses
+    // the resulting PK2 stress for material tangent, geometric tangent, stored
+    // integration-point state and matching internal force.
     MapMatrix mass             (Precision* buffer) override;
     MapMatrix conductivity     (Precision* buffer) override;
     MapMatrix capacity         (Precision* buffer) override;

--- a/src/model/solid/element_solid.ipp
+++ b/src/model/solid/element_solid.ipp
@@ -6,7 +6,7 @@
  * linearized and Total-Lagrangian strain-displacement operators, transform
  * constitutive response through `SolidSection` and integrate element matrices.
  *
- * Constitutive calls receive the globally enumerated material-point state row
+ * Constitutive calls receive globally enumerated old/new material-point rows
  * selected by their caller. The element applies optional topology stiffness
  * scaling only after the section has returned stress and tangent.
  *
@@ -108,7 +108,7 @@ Vec3 SolidElement<N>::material_position_reference(Precision r, Precision s, Prec
  * Evaluates linearized solid constitutive response at one natural point.
  *
  * The physical reference position, optional additional material rotation and
- * caller-selected state row are forwarded to `SolidSection`. Returned global
+ * caller-selected state rows are forwarded to `SolidSection`. Returned global
  * Cauchy stress and tangent are then multiplied by the optional scalar topology
  * stiffness field associated with this element.
  *
@@ -116,7 +116,8 @@ Vec3 SolidElement<N>::material_position_reference(Precision r, Precision s, Prec
  * @param s Second natural coordinate.
  * @param t Third natural coordinate.
  * @param global_strain Linearized strain in global coordinates.
- * @param state Active material-point history row.
+ * @param old_state Immutable material-point input state row.
+ * @param new_state Material-point output state row.
  * @param global_stress Cauchy stress returned in global coordinates.
  * @param global_tangent Consistent global material tangent.
  */
@@ -125,14 +126,16 @@ void SolidElement<N>::evaluate_material(Precision                     r,
                                         Precision                     s,
                                         Precision                     t,
                                         const VolumeStrainLinearized& global_strain,
-                                        Precision*                    state,
+                                        const Precision*              old_state,
+                                        Precision*                    new_state,
                                         VolumeStressCauchy&           global_stress,
                                         Mat6&                         global_tangent) {
     get_section()->evaluate(
         material_position_reference(r, s, t),
         additional_material_rotation(),
         global_strain,
-        state,
+        old_state,
+        new_state,
         global_stress,
         global_tangent
     );
@@ -145,7 +148,7 @@ void SolidElement<N>::evaluate_material(Precision                     r,
 /**
  * Evaluates Total-Lagrangian solid constitutive response at one natural point.
  *
- * The selected state row is passed directly to the section and constitutive law.
+ * The selected old/new rows are passed directly to the section and constitutive law.
  * Green-Lagrange strain, returned PK2 stress and `dS/dE` are all expressed in
  * global reference coordinates. Optional topology scaling is applied to both
  * output quantities after constitutive evaluation.
@@ -154,7 +157,8 @@ void SolidElement<N>::evaluate_material(Precision                     r,
  * @param s Second natural coordinate.
  * @param t Third natural coordinate.
  * @param global_strain Green-Lagrange strain in global reference coordinates.
- * @param state Active material-point history row.
+ * @param old_state Immutable material-point input state row.
+ * @param new_state Material-point output state row.
  * @param global_stress PK2 stress returned in global reference coordinates.
  * @param global_tangent Consistent global material tangent `dS/dE`.
  */
@@ -163,14 +167,16 @@ void SolidElement<N>::evaluate_material(Precision                        r,
                                         Precision                        s,
                                         Precision                        t,
                                         const VolumeStrainGreenLagrange& global_strain,
-                                        Precision*                       state,
+                                        const Precision*                 old_state,
+                                        Precision*                       new_state,
                                         VolumeStressPK2&                 global_stress,
                                         Mat6&                            global_tangent) {
     get_section()->evaluate(
         material_position_reference(r, s, t),
         additional_material_rotation(),
         global_strain,
-        state,
+        old_state,
+        new_state,
         global_stress,
         global_tangent
     );
@@ -262,23 +268,24 @@ auto SolidElement<N>::green_lagrange_strain_displacement(const StaticMatrix<N, D
  * Evaluates the zero-strain Total-Lagrangian material tangent at one natural
  * coordinate.
  *
- * The provided state row follows the ordinary in-place constitutive contract.
- * Callers performing an auxiliary tangent query, such as hourglass scaling,
- * must save and restore it when the query must not advance physical history.
+ * The provided old state row remains unchanged. Any history generated by the
+ * auxiliary tangent query is written to the supplied new state row.
  *
  * @param r First natural coordinate.
  * @param s Second natural coordinate.
  * @param t Third natural coordinate.
- * @param state Active material-point state row.
+ * @param old_state Immutable material-point input state row.
+ * @param new_state Material-point output state row.
  * @return Global material tangent at zero Green-Lagrange strain.
  */
 template<Index N>
-auto SolidElement<N>::material_tangent_reference(Precision r, Precision s, Precision t, Precision* state)
+auto SolidElement<N>::material_tangent_reference(Precision r, Precision s, Precision t,
+                                                 const Precision* old_state, Precision* new_state)
     -> StaticMatrix<n_strain, n_strain> {
     VolumeStrainGreenLagrange zero_strain;
     VolumeStressPK2           zero_stress;
     Mat6                      tangent;
-    evaluate_material(r, s, t, zero_strain, state, zero_stress, tangent);
+    evaluate_material(r, s, t, zero_strain, old_state, new_state, zero_stress, tangent);
     return tangent;
 }
 
@@ -499,8 +506,10 @@ SolidElement<N>::stiffness(Precision* buffer) {
             VolumeStressPK2 stress;
             Mat6            C;
 
-            Precision* state = &(*this->_model_data->material_state)(this->mp_index(ip++), 0);
-            evaluate_material(r, s, t, strain, state, stress, C);
+            const Index      state_row = this->mp_index(ip++);
+            const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+            Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
+            evaluate_material(r, s, t, strain, old_state, new_state, stress, C);
 
             StaticMatrix<D * N, D * N> res = B.transpose() * (C * B) * det0;
             return StaticMatrix<D * N, D * N>(res);

--- a/src/model/solid/element_solid_compute.ipp
+++ b/src/model/solid/element_solid_compute.ipp
@@ -2,10 +2,9 @@
  * @file element_solid_compute.ipp
  * @brief Implements solid stress recovery and nonlinear force/tangent assembly.
  *
- * Constitutive evaluations use the globally enumerated material-point state
+ * Constitutive evaluations use separate globally enumerated old/new state rows
  * associated with each solid integration point. The nonlinear tangent path
- * evaluates stress and material tangent together so an in-place history state
- * is advanced exactly once per material point and solver evaluation.
+ * evaluates stress and material tangent together in one material call.
  *
  * @author Finn Eggers
  * @date 07.08.2026
@@ -85,7 +84,9 @@ void SolidElement<N>::compute_stress_strain(Field* strain,
             }
         }
 
-        Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip), 0);
+        const Index      state_row = this->mp_index(state_ip);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         // Linearized recovery evaluates Cauchy stress directly from the
         // infinitesimal reference-configuration strain field
@@ -102,7 +103,7 @@ void SolidElement<N>::compute_stress_strain(Field* strain,
             const VolumeStrainLinearized global_strain(global_strain_voigt);
             VolumeStressCauchy           global_stress;
             Mat6                         global_tangent;
-            evaluate_material(r, s, t, global_strain, state, global_stress, global_tangent);
+            evaluate_material(r, s, t, global_strain, old_state, new_state, global_stress, global_tangent);
 
             for (Dim j = 0; j < n_strain; ++j) {
                 if (strain) (*strain)(row, j) = global_strain.voigt()(j);
@@ -119,7 +120,7 @@ void SolidElement<N>::compute_stress_strain(Field* strain,
 
         VolumeStressPK2 second_pk;
         Mat6            tangent;
-        evaluate_material(r, s, t, green_lagrange, state, second_pk, tangent);
+        evaluate_material(r, s, t, green_lagrange, old_state, new_state, second_pk, tangent);
 
         const VolumeStressCauchy cauchy = second_pk.to_cauchy(F);
 
@@ -166,8 +167,10 @@ void SolidElement<N>::compute_stress_state(Field& stress_state,
         const Precision r   = rst(n, 0);
         const Precision s   = rst(n, 1);
         const Precision t   = rst(n, 2);
-        const Index     row = static_cast<Index>(offset + n);
-        Precision*      state = &(*this->_model_data->material_state)(this->mp_index(static_cast<Index>(n)), 0);
+        const Index      row       = static_cast<Index>(offset + n);
+        const Index      state_row = this->mp_index(static_cast<Index>(n));
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         // Store linearized Cauchy stress directly when small-strain recovery is requested
         if (!use_green_lagrange_nl) {
@@ -183,7 +186,7 @@ void SolidElement<N>::compute_stress_state(Field& stress_state,
             const VolumeStrainLinearized strain(strain_voigt);
             VolumeStressCauchy           cauchy;
             Mat6                         tangent;
-            evaluate_material(r, s, t, strain, state, cauchy, tangent);
+            evaluate_material(r, s, t, strain, old_state, new_state, cauchy, tangent);
 
             for (Dim component = 0; component < n_strain; ++component) {
                 stress_state(row, component) = cauchy.voigt()(component);
@@ -198,7 +201,7 @@ void SolidElement<N>::compute_stress_state(Field& stress_state,
 
         VolumeStressPK2 second_pk;
         Mat6            tangent;
-        evaluate_material(r, s, t, green_lagrange, state, second_pk, tangent);
+        evaluate_material(r, s, t, green_lagrange, old_state, new_state, second_pk, tangent);
 
         // Total-Lagrange internal forces and geometric stiffness require PK2.
         for (Dim component = 0; component < n_strain; ++component) {
@@ -260,11 +263,14 @@ MapMatrix SolidElement<N>::stiffness_tangent(Precision*   buffer,
         const VolumeStrainGreenLagrange strain =
             VolumeStrainGreenLagrange::from_deformation_gradient(F);
 
-        Precision* state = &(*this->_model_data->material_state)(this->mp_index(ip), 0);
+        const Index      state_row = this->mp_index(ip);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         VolumeStressPK2 stress;
         Mat6            material_tangent;
-        evaluate_material(point.r, point.s, point.t, strain, state, stress, material_tangent);
+        evaluate_material(point.r, point.s, point.t, strain,
+                          old_state, new_state, stress, material_tangent);
 
         // Store the freshly evaluated PK2 stress in the common integration-point field.
         const Index stress_row = this->ip_index(ip);
@@ -490,13 +496,16 @@ void SolidElement<N>::compute_compliance_angle_derivative(Field& displacement, F
         // using the material state row of this integration point
         const Vec3 position_reference =
             this->interpolate<D>(reference_coords, point.r, point.s, point.t);
-        Precision* state = &(*this->_model_data->material_state)(this->mp_index(n), 0);
+        const Index      state_row = this->mp_index(n);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         const auto tangent_derivatives = get_section()->tangent_rotation_derivatives(
             position_reference,
             additional_rotation,
             additional_rotation_derivatives,
-            state
+            old_state,
+            new_state
         );
 
         // Accumulate epsilon^T C'_tan epsilon with the physical volume measure

--- a/src/model/solid/element_solid_load.ipp
+++ b/src/model/solid/element_solid_load.ipp
@@ -30,8 +30,8 @@ namespace fem::model {
  *
  * Load and stiffness quadrature may differ. Each auxiliary load point therefore
  * reuses the state row of the nearest constitutive stiffness point in natural
- * coordinates. The material tangent call follows the ordinary in-place state
- * contract; no additional state storage is owned by this routine.
+ * coordinates. The material tangent call reads the old state and writes the
+ * separate new state; no additional storage is owned by this routine.
  *
  * @param node_loads Global nodal thermal-load field to increment.
  * @param node_temp Scalar nodal temperature field.
@@ -98,10 +98,12 @@ SolidElement<N>::apply_tload(Field& node_loads, const Field& node_temp, Precisio
             }
         }
 
-        Precision* state = &(*this->_model_data->material_state)(this->mp_index(state_ip), 0);
+        const Index      state_row = this->mp_index(state_ip);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
         // Convert free thermal strain to stress using the selected state-row tangent
-        auto mat_matrix = material_tangent_reference(r, s, t, state);
+        auto mat_matrix = material_tangent_reference(r, s, t, old_state, new_state);
         auto stress = mat_matrix * strain;
 
         // Map thermal stress to its element nodal-force contribution

--- a/src/model/truss/truss.cpp
+++ b/src/model/truss/truss.cpp
@@ -5,8 +5,8 @@
  * The truss evaluates axial material response at one globally enumerated
  * material point. Linearized output uses Cauchy stress; the nonlinear element
  * uses Green-Lagrange strain and PK2 stress in a Total-Lagrangian formulation.
- * The nonlinear residual and tangent share one constitutive update so the
- * in-place material history is advanced only once per solver evaluation.
+ * The nonlinear residual and tangent share one constitutive update from the old
+ * material state into the separate new state.
  *
  * @see T3
  *
@@ -201,9 +201,11 @@ MapMatrix T3::stiffness(Precision* buffer) {
     logging::error(elasticity->supports_axial_green_lagrange(),
         "T3: material does not support Green-Lagrange axial evaluation for element ", this->elem_id);
 
-    // Evaluate the single constitutive material point in place
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(0), 0);
-    elasticity->evaluate(axial_strain, state, axial_stress, material_tangent);
+    // Evaluate the single constitutive material point from committed history
+    const Index      state_row = this->mp_index(0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
+    elasticity->evaluate(axial_strain, old_state, new_state, axial_stress, material_tangent);
 
     const Vec3 n = direction_current();
     const Mat3 k = (A0 * material_tangent * lambda * lambda / L0) * (n * n.transpose());
@@ -251,7 +253,7 @@ MapMatrix T3::stiffness_geom(Precision* buffer, const Field& ip_stress, int ip_s
  * `A0 C lambda^2 / L0`. The PK2 stress from the same material call produces the
  * geometric contribution `A0 S / L0` and the internal force
  * `A0 lambda S n`. This avoids the generic structural path, which would evaluate
- * an in-place material history separately for stress and material tangent.
+ * material history separately for stress and material tangent.
  *
  * @param buffer Caller-provided six-by-six tangent storage.
  * @param ip_stress_state Global integration-point field receiving axial PK2 stress.
@@ -288,8 +290,10 @@ MapMatrix T3::stiffness_tangent(Precision*   buffer,
     logging::error(elasticity->supports_axial_green_lagrange(),
         "T3: material does not support Green-Lagrange axial evaluation for element ", this->elem_id);
 
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(0), 0);
-    elasticity->evaluate(strain, state, stress, material_tangent);
+    const Index      state_row = this->mp_index(0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
+    elasticity->evaluate(strain, old_state, new_state, stress, material_tangent);
 
     // Preserve PK2 stress for state-based residual and geometric-stiffness paths
     ip_stress_state(this->ip_index(0), 0) = stress.value();
@@ -442,9 +446,12 @@ void T3::compute_stress_strain(Field*           strain,
     logging::error(rst.cols() >= 1,
         "T3: stress/strain coordinates require at least 1 column");
 
-    Precision  strain_value = Precision(0);
-    Precision  stress_value = Precision(0);
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(0), 0);
+    Precision strain_value = Precision(0);
+    Precision stress_value = Precision(0);
+
+    const Index      state_row = this->mp_index(0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
 
     // Evaluate finite-strain PK2 stress and convert it to physical Cauchy stress
     if (use_green_lagrange_nl) {
@@ -457,7 +464,7 @@ void T3::compute_stress_strain(Field*           strain,
         auto elasticity = get_elasticity();
         logging::error(elasticity->supports_axial_green_lagrange(),
             "T3: material does not support Green-Lagrange axial evaluation for element ", this->elem_id);
-        elasticity->evaluate(axial_strain, state, axial_stress, tangent);
+        elasticity->evaluate(axial_strain, old_state, new_state, axial_stress, tangent);
 
         const AxialStressCauchy cauchy(lambda * axial_stress.value());
         strain_value = axial_strain.value();
@@ -480,7 +487,7 @@ void T3::compute_stress_strain(Field*           strain,
         auto elasticity = get_elasticity();
         logging::error(elasticity->supports_axial_linearized(),
             "T3: material does not support linearized axial evaluation for element ", this->elem_id);
-        elasticity->evaluate(axial_strain, state, axial_stress, tangent);
+        elasticity->evaluate(axial_strain, old_state, new_state, axial_stress, tangent);
 
         strain_value = axial_strain.value();
         stress_value = axial_stress.value();
@@ -511,8 +518,8 @@ void T3::compute_stress_strain(Field*           strain,
  *
  * Nonlinear Total-Lagrangian recovery stores PK2 stress at the single truss
  * integration point. Linearized recovery delegates to the ordinary Cauchy-
- * stress output path. The active material state row may be updated in place by
- * either constitutive evaluation.
+ * stress output path. Either constitutive evaluation reads the old state row and
+ * writes its result to the separate new row.
  *
  * @param stress_state Global integration-point stress field to update.
  * @param displacement Global nodal displacement field.
@@ -534,8 +541,10 @@ void T3::compute_stress_state(Field&       stress_state,
         logging::error(elasticity->supports_axial_green_lagrange(),
             "T3: material does not support Green-Lagrange axial evaluation for element ", this->elem_id);
 
-        Precision* state = &(*this->_model_data->material_state)(this->mp_index(0), 0);
-        elasticity->evaluate(axial_strain, state, axial_stress, tangent);
+        const Index      state_row = this->mp_index(0);
+        const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+        Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
+        elasticity->evaluate(axial_strain, old_state, new_state, axial_stress, tangent);
 
         const RowMatrix rst = stress_strain_ip_rst();
         for (Index i = 0; i < static_cast<Index>(rst.rows()); ++i) {
@@ -638,8 +647,10 @@ bool T3::compute_beam_section_forces(Field&       section_forces,
     logging::error(elasticity->supports_axial_linearized(),
         "T3: material does not support linearized axial evaluation for element ", this->elem_id);
 
-    Precision* state = &(*this->_model_data->material_state)(this->mp_index(0), 0);
-    elasticity->evaluate(axial_strain, state, axial_stress, tangent);
+    const Index      state_row = this->mp_index(0);
+    const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
+    Precision*       new_state = &(*this->_model_data->material_state_new)(state_row, 0);
+    elasticity->evaluate(axial_strain, old_state, new_state, axial_stress, tangent);
 
     const Precision axial_force = get_section()->area_ * axial_stress.value();
 

--- a/src/model/truss/truss.h
+++ b/src/model/truss/truss.h
@@ -5,7 +5,7 @@
  * The truss supports linearized axial output and a Total-Lagrangian nonlinear
  * formulation based on Green-Lagrange strain and PK2 stress. Its single
  * constitutive material point is addressed directly through the model material
- * state field.
+ * input/output state fields.
  *
  * @author Finn Eggers
  * @date 07.08.2026
@@ -33,8 +33,7 @@ namespace model {
  *
  * The nonlinear tangent evaluates axial PK2 stress and its material tangent in
  * one constitutive call. The same stress drives geometric stiffness and internal
- * force, preventing an in-place history state from advancing twice within one
- * solver evaluation.
+ * force, while history is read from the old row and written to the new row.
  */
 struct T3 : StructuralElement {
     static constexpr Index N = 2;

--- a/src/section/section_shell.cpp
+++ b/src/section/section_shell.cpp
@@ -76,7 +76,8 @@ ShellSection::ShellSection(
  * @param position_reference Physical reference position of the shell point.
  * @param shell_basis_global Geometric shell basis expressed in global coordinates.
  * @param strain_shell Generalized strain in the geometric shell basis.
- * @param material_state First material-point state row at this shell point.
+ * @param old_material_state First material-point input state row at this shell point.
+ * @param new_material_state First material-point output state row at this shell point.
  * @param material_state_stride Scalar distance between consecutive state rows.
  * @param use_green_lagrange Select finite-strain constitutive evaluation.
  * @return Generalized resultants in the configured output basis.
@@ -85,7 +86,8 @@ ShellStressResultants ShellSection::evaluate_output_resultants(
     const Vec3&                   position_reference,
     const Mat3&                   shell_basis_global,
     const ShellGeneralizedStrain& strain_shell,
-    Precision*                    material_state,
+    const Precision*              old_material_state,
+    Precision*                    new_material_state,
     Index                         material_state_stride,
     bool                          use_green_lagrange
 ) const {
@@ -99,7 +101,8 @@ ShellStressResultants ShellSection::evaluate_output_resultants(
         position_reference,
         shell_basis_global,
         strain_shell,
-        material_state,
+        old_material_state,
+        new_material_state,
         material_state_stride,
         use_green_lagrange,
         resultants_shell,

--- a/src/section/section_shell.h
+++ b/src/section/section_shell.h
@@ -71,15 +71,17 @@ struct ShellSection : Section {
 
     // Evaluate generalized membrane forces, bending moments, transverse shear
     // forces and their consistent eight-by-eight tangent. Input strain and both
-    // outputs use the supplied geometric shell basis. material_state addresses
-    // the first through-thickness material point at the current shell IP;
-    // material_state_stride is the scalar distance to each following row.
+    // outputs use the supplied geometric shell basis. old_material_state and
+    // new_material_state address the first through-thickness input/output rows
+    // at the current shell IP; material_state_stride is the scalar distance to
+    // each following row.
     // Concrete sections perform all material-basis transformations internally.
     virtual void evaluate(
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         bool                          use_green_lagrange,
         ShellStressResultants&        resultants_shell,
@@ -87,15 +89,16 @@ struct ShellSection : Section {
     ) const = 0;
 
     // Recover generalized resultants for output. The concrete section is first
-    // evaluated with the same state pointer, stride and strain-measure contract
+    // evaluated with the same state rows, stride and strain-measure contract
     // as evaluate(). The base then rotates physical membrane, moment and shear
     // components from the geometric shell basis into stress_resultant_basis().
-    // Any in-place constitutive state update occurs during the concrete call.
+    // Constitutive history updates are written only to the new state rows.
     [[nodiscard]] ShellStressResultants evaluate_output_resultants(
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         bool                          use_green_lagrange
     ) const;
@@ -104,13 +107,14 @@ struct ShellSection : Section {
     // the midsurface. Linearized sections return Cauchy stress directly;
     // finite-strain sections use deformation_gradient to push their PK2 material
     // response forward. Components are global without an orientation and
-    // section-local with one. material_state identifies the first state row at
-    // the parent shell IP and the concrete formulation chooses the relevant MP.
+    // section-local with one. Both state pointers identify the first row at the
+    // parent shell IP and the concrete formulation chooses the relevant MP.
     [[nodiscard]] virtual VolumeStressCauchy evaluate_output_stress(
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         Precision                     z,
         bool                          use_green_lagrange,

--- a/src/section/section_shell_abd.cpp
+++ b/src/section/section_shell_abd.cpp
@@ -98,13 +98,14 @@ ABDShellSection::ABDShellSection(
  * element assembly.
  *
  * The formulation is linear elastic and contains no material-point history.
- * Consequently, `material_state`, its stride and the kinematic strain-measure
+ * Consequently, the state rows, their stride and the kinematic strain-measure
  * selector do not change the prescribed response.
  *
  * @param position_reference Physical reference position of the shell point.
  * @param shell_basis_global Geometric shell basis in global coordinates.
  * @param strain_shell Generalized strain in the geometric shell basis.
- * @param material_state Unused state row retained by the common section interface.
+ * @param old_material_state Unused input state row.
+ * @param new_material_state Unused output state row.
  * @param material_state_stride Unused state-row stride.
  * @param use_green_lagrange Unused strain-measure selector for this linear law.
  * @param resultants_shell Generalized resultants in the geometric shell basis.
@@ -114,14 +115,16 @@ void ABDShellSection::evaluate(
     const Vec3&                   position_reference,
     const Mat3&                   shell_basis_global,
     const ShellGeneralizedStrain& strain_shell,
-    Precision*                    material_state,
+    const Precision*              old_material_state,
+    Precision*                    new_material_state,
     Index                         material_state_stride,
     bool                          use_green_lagrange,
     ShellStressResultants&        resultants_shell,
     Mat8&                         tangent_shell
 ) const {
     // A prescribed linear generalized stiffness has no constitutive history.
-    (void) material_state;
+    (void) old_material_state;
+    (void) new_material_state;
     (void) material_state_stride;
     (void) use_green_lagrange;
 
@@ -206,7 +209,8 @@ void ABDShellSection::evaluate(
  * @param position_reference Physical reference position of the shell point.
  * @param shell_basis_global Geometric shell basis in global coordinates.
  * @param strain_shell Generalized strain in the geometric shell basis.
- * @param material_state Unused state row retained by the common section interface.
+ * @param old_material_state Unused input state row.
+ * @param new_material_state Unused output state row.
  * @param material_state_stride Unused state-row stride.
  * @param z Physical thickness coordinate measured from the midsurface.
  * @param use_green_lagrange Select PK2-to-Cauchy push-forward for nonlinear output.
@@ -217,14 +221,16 @@ VolumeStressCauchy ABDShellSection::evaluate_output_stress(
     const Vec3&                   position_reference,
     const Mat3&                   shell_basis_global,
     const ShellGeneralizedStrain& strain_shell,
-    Precision*                    material_state,
+    const Precision*              old_material_state,
+    Precision*                    new_material_state,
     Index                         material_state_stride,
     Precision                     z,
     bool                          use_green_lagrange,
     const Mat3&                   deformation_gradient
 ) const {
     // The prescribed ABD reconstruction does not contain constitutive history.
-    (void) material_state;
+    (void) old_material_state;
+    (void) new_material_state;
     (void) material_state_stride;
 
     const Precision h = thickness_;

--- a/src/section/section_shell_abd.h
+++ b/src/section/section_shell_abd.h
@@ -55,14 +55,15 @@ struct ABDShellSection : ShellSection {
     // Apply the constant ABD and transverse-shear operators. Generalized strain
     // is rotated into the prescribed section basis and resultants/tangent are
     // returned in the geometric shell basis. The formulation has no history:
-    // material_state and material_state_stride are accepted for interface
+    // the state rows and material_state_stride are accepted for interface
     // uniformity but never read or modified, and the strain-measure selector
     // does not alter the linear generalized law.
     void evaluate(
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         bool                          use_green_lagrange,
         ShellStressResultants&        resultants_shell,
@@ -78,7 +79,8 @@ struct ABDShellSection : ShellSection {
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         Precision                     z,
         bool                          use_green_lagrange,

--- a/src/section/section_shell_integrated.cpp
+++ b/src/section/section_shell_integrated.cpp
@@ -85,8 +85,8 @@ IntegratedShellSection::IntegratedShellSection(
  * Integrates one shell integration point through the five physical material
  * points of the section.
  *
- * `material_state` points to the first material-point row belonging to the shell
- * integration point. Consecutive rows are separated by
+ * The state pointers address the first old/new material-point rows belonging to
+ * the shell integration point. Consecutive rows are separated by
  * `material_state_stride` scalar components and are passed directly to the
  * constitutive model without additional state ownership in the section.
  *
@@ -100,7 +100,8 @@ IntegratedShellSection::IntegratedShellSection(
  * @param position_reference Physical reference position of the shell point.
  * @param shell_basis_global Geometric shell basis in global coordinates.
  * @param strain_shell Generalized strain in the geometric shell basis.
- * @param material_state First of the five through-thickness state rows.
+ * @param old_material_state First of the five through-thickness input state rows.
+ * @param new_material_state First of the five through-thickness output state rows.
  * @param material_state_stride Scalar distance between consecutive state rows.
  * @param use_green_lagrange Select PK2 or linearized Cauchy material evaluation.
  * @param resultants_shell Integrated resultants in the geometric shell basis.
@@ -110,7 +111,8 @@ void IntegratedShellSection::evaluate(
     const Vec3&                   position_reference,
     const Mat3&                   shell_basis_global,
     const ShellGeneralizedStrain& strain_shell,
-    Precision*                    material_state,
+    const Precision*              old_material_state,
+    Precision*                    new_material_state,
     Index                         material_state_stride,
     bool                          use_green_lagrange,
     ShellStressResultants&        resultants_shell,
@@ -213,7 +215,8 @@ void IntegratedShellSection::evaluate(
 
         ShellMaterialStress material_stress;
         Mat5                material_tangent;
-        Precision*          state = material_state + mp * material_state_stride;
+        const Precision* old_state = old_material_state + mp * material_state_stride;
+        Precision*       new_state = new_material_state + mp * material_state_stride;
 
         // Evaluate either PK2 stress conjugate to Green-Lagrange strain or
         // Cauchy stress for the linearized shell response.
@@ -223,7 +226,8 @@ void IntegratedShellSection::evaluate(
 
             material_->elasticity()->evaluate(
                 material_strain_gl,
-                state,
+                old_state,
+                new_state,
                 material_stress_pk2,
                 material_tangent
             );
@@ -235,7 +239,8 @@ void IntegratedShellSection::evaluate(
 
             material_->elasticity()->evaluate(
                 material_strain_linearized,
-                state,
+                old_state,
+                new_state,
                 material_stress_cauchy,
                 material_tangent
             );
@@ -329,7 +334,8 @@ void IntegratedShellSection::evaluate(
  * @param position_reference Physical reference position of the shell point.
  * @param shell_basis_global Geometric shell basis in global coordinates.
  * @param strain_shell Generalized strain in the geometric shell basis.
- * @param material_state First of the five through-thickness state rows.
+ * @param old_material_state First of the five through-thickness input state rows.
+ * @param new_material_state First of the five through-thickness output state rows.
  * @param material_state_stride Scalar distance between consecutive state rows.
  * @param z Physical thickness coordinate measured from the midsurface.
  * @param use_green_lagrange Select PK2-to-Cauchy finite-strain recovery.
@@ -340,7 +346,8 @@ VolumeStressCauchy IntegratedShellSection::evaluate_output_stress(
     const Vec3&                   position_reference,
     const Mat3&                   shell_basis_global,
     const ShellGeneralizedStrain& strain_shell,
-    Precision*                    material_state,
+    const Precision*              old_material_state,
+    Precision*                    new_material_state,
     Index                         material_state_stride,
     Precision                     z,
     bool                          use_green_lagrange,
@@ -420,7 +427,8 @@ VolumeStressCauchy IntegratedShellSection::evaluate_output_stress(
         }
     }
 
-    Precision* state = material_state + state_mp * material_state_stride;
+    const Precision* old_state = old_material_state + state_mp * material_state_stride;
+    Precision*       new_state = new_material_state + state_mp * material_state_stride;
 
     // Convert five plane-stress shell components into a symmetric 3D tensor in
     // the recovery basis.
@@ -449,7 +457,8 @@ VolumeStressCauchy IntegratedShellSection::evaluate_output_stress(
 
         material_->elasticity()->evaluate(
             material_strain_linearized,
-            state,
+            old_state,
+            new_state,
             material_stress_cauchy,
             material_tangent
         );
@@ -465,7 +474,8 @@ VolumeStressCauchy IntegratedShellSection::evaluate_output_stress(
 
     material_->elasticity()->evaluate(
         material_strain_gl,
-        state,
+        old_state,
+        new_state,
         material_stress_pk2,
         material_tangent
     );

--- a/src/section/section_shell_integrated.h
+++ b/src/section/section_shell_integrated.h
@@ -44,15 +44,16 @@ struct IntegratedShellSection : ShellSection {
 
     // Reconstruct epsilon(z) = epsilon_0 + z kappa at five physical material
     // points and integrate stress into membrane forces, moments and corrected
-    // transverse shear forces. material_state identifies the first MP row and
-    // material_state_stride advances through its four following rows. Each row
-    // is passed directly to the selected linearized or Green-Lagrange material
-    // evaluation, and the consistent tangent is integrated by the same rule.
+    // transverse shear forces. The state pointers identify the first old/new MP
+    // rows and material_state_stride advances through their four following rows.
+    // Each pair is passed to the selected material evaluation, and the
+    // consistent tangent is integrated by the same rule.
     void evaluate(
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         bool                          use_green_lagrange,
         ShellStressResultants&        resultants_shell,
@@ -68,7 +69,8 @@ struct IntegratedShellSection : ShellSection {
         const Vec3&                   position_reference,
         const Mat3&                   shell_basis_global,
         const ShellGeneralizedStrain& strain_shell,
-        Precision*                    material_state,
+        const Precision*              old_material_state,
+        Precision*                    new_material_state,
         Index                         material_state_stride,
         Precision                     z,
         bool                          use_green_lagrange,

--- a/src/section/section_solid.cpp
+++ b/src/section/section_solid.cpp
@@ -9,8 +9,8 @@
  * linear tangent with respect to additional material-rotation parameters.
  *
  * Material-point history remains owned by the active nonlinear solution. The
- * section receives one selected state row and forwards it unchanged to the
- * constitutive model.
+ * section receives separate selected input and output rows and forwards both to
+ * the constitutive model.
  *
  * @see SolidSection
  * @see material::Elasticity
@@ -55,20 +55,22 @@ Mat3 SolidSection::section_orientation_basis(const Vec3& position_reference) con
  * through the assigned elasticity and transformed back to global coordinates.
  * The tangent follows the identical chain of stress and strain transformations.
  *
- * The selected material-point state row is passed directly to the constitutive
- * law and may be updated in place by a history-dependent model.
+ * The selected old material-point state row is passed read-only to the
+ * constitutive law, which writes updated history to the corresponding new row.
  *
  * @param position_reference Physical reference position of the material point.
  * @param additional_rotation Element-provided rotation applied after the section basis.
  * @param strain_global Linearized engineering strain in global coordinates.
- * @param state Active material-point state row.
+ * @param old_state Immutable material-point input state row.
+ * @param new_state Material-point output state row.
  * @param stress_global Cauchy stress returned in global coordinates.
  * @param tangent_global Consistent global tangent mapping global strain to stress.
  */
 void SolidSection::evaluate(const Vec3&                   position_reference,
                             const Mat3&                   additional_rotation,
                             const VolumeStrainLinearized& strain_global,
-                            Precision*                    state,
+                            const Precision*              old_state,
+                            Precision*                    new_state,
                             VolumeStressCauchy&           stress_global,
                             Mat6&                         tangent_global) const {
     // Validate the requested constitutive formulation before transformation
@@ -97,7 +99,7 @@ void SolidSection::evaluate(const Vec3&                   position_reference,
     // material-point state row
     VolumeStressCauchy stress_material;
     Mat6               tangent_material;
-    elasticity->evaluate(strain_material, state, stress_material, tangent_material);
+    elasticity->evaluate(strain_material, old_state, new_state, stress_material, tangent_material);
 
     // Transform stress and the complete tangent back into global coordinates:
     // C_global = T_stress C_material T_strain
@@ -118,14 +120,16 @@ void SolidSection::evaluate(const Vec3&                   position_reference,
  * @param position_reference Physical reference position of the material point.
  * @param additional_rotation Element-provided rotation applied after the section basis.
  * @param strain_global Green-Lagrange strain in global reference coordinates.
- * @param state Active material-point state row.
+ * @param old_state Immutable material-point input state row.
+ * @param new_state Material-point output state row.
  * @param stress_global PK2 stress returned in global reference coordinates.
  * @param tangent_global Consistent global material tangent `dS/dE`.
  */
 void SolidSection::evaluate(const Vec3&                      position_reference,
                             const Mat3&                      additional_rotation,
                             const VolumeStrainGreenLagrange& strain_global,
-                            Precision*                       state,
+                            const Precision*                 old_state,
+                            Precision*                       new_state,
                             VolumeStressPK2&                 stress_global,
                             Mat6&                            tangent_global) const {
     // Validate the requested constitutive formulation before transformation
@@ -154,7 +158,7 @@ void SolidSection::evaluate(const Vec3&                      position_reference,
     VolumeStressPK2 stress_material;
     Mat6            tangent_material;
 
-    elasticity->evaluate(strain_material, state, stress_material, tangent_material);
+    elasticity->evaluate(strain_material, old_state, new_state, stress_material, tangent_material);
 
     // Transform PK2 stress and tangent back into the global reference basis:
     // C_global = T_stress C_material T_strain
@@ -171,14 +175,16 @@ void SolidSection::evaluate(const Vec3&                      position_reference,
  * @param position_reference Reference position of the material point.
  * @param additional_rotation Current additional material rotation.
  * @param additional_rotation_derivatives Derivatives of the additional rotation.
- * @param state Active material-point state selected by the element.
+ * @param old_state Immutable material-point input state selected by the element.
+ * @param new_state Material-point output state selected by the element.
  * @return Derivatives of the global tangent with respect to the three angles.
  */
 std::array<Mat6, 3> SolidSection::tangent_rotation_derivatives(
     const Vec3&                position_reference,
     const Mat3&                additional_rotation,
     const std::array<Mat3, 3>& additional_rotation_derivatives,
-    Precision*                 state
+    const Precision*           old_state,
+    Precision*                 new_state
 ) const {
     // Validate the linear elastic constitutive response used by this sensitivity
     logging::error(material_ && material_->has_elasticity(),
@@ -199,7 +205,7 @@ std::array<Mat6, 3> SolidSection::tangent_rotation_derivatives(
     VolumeStrainLinearized zero_strain;
     VolumeStressCauchy     zero_stress;
     Mat6                   tangent_material;
-    elasticity->evaluate(zero_strain, state, zero_stress, tangent_material);
+    elasticity->evaluate(zero_strain, old_state, new_state, zero_stress, tangent_material);
 
     // The material basis is composed of the prescribed section orientation Q_section and an
     // additional rotation R:

--- a/src/section/section_solid.h
+++ b/src/section/section_solid.h
@@ -5,7 +5,7 @@
  * `SolidSection` transforms global solid strains into the optional material
  * coordinate system, evaluates the assigned elasticity model and transforms
  * stresses and consistent tangents back into the global basis. The element owns
- * material-point addressing and supplies the active state pointer directly.
+ * material-point addressing and supplies separate input and output state rows.
  *
  * @see SolidSection
  * @see src/section/section_solid.cpp
@@ -32,8 +32,8 @@ namespace fem {
  * @brief Constitutive section for three-dimensional solid elements.
  *
  * The section owns the optional material orientation but no material-point
- * history. Every constitutive call receives the state row selected by the
- * element. Linearized response returns Cauchy stress, while finite-strain
+ * history. Every constitutive call receives the old and new state rows selected
+ * by the element. Linearized response returns Cauchy stress, while finite-strain
  * response uses Green-Lagrange strain and PK2 stress in the reference material
  * basis before transformation back to global coordinates.
  */
@@ -51,7 +51,8 @@ struct SolidSection : Section {
     void evaluate(const Vec3&                   position_reference,
                   const Mat3&                   additional_rotation,
                   const VolumeStrainLinearized& strain_global,
-                  Precision*                    state,
+                  const Precision*              old_state,
+                  Precision*                    new_state,
                   VolumeStressCauchy&           stress_global,
                   Mat6&                         tangent_global) const;
 
@@ -62,20 +63,22 @@ struct SolidSection : Section {
     void evaluate(const Vec3&                      position_reference,
                   const Mat3&                      additional_rotation,
                   const VolumeStrainGreenLagrange& strain_global,
-                  Precision*                       state,
+                  const Precision*                 old_state,
+                  Precision*                       new_state,
                   VolumeStressPK2&                 stress_global,
                   Mat6&                            tangent_global) const;
 
     // Differentiate the globally transformed linear material tangent with
     // respect to three supplied additional-rotation directions. The material
-    // tangent is evaluated at zero strain using the active state row and is
-    // assumed independent of the rotation parameters; only strain and stress
-    // transformation operators are differentiated.
+    // tangent is evaluated at zero strain using the selected old/new state rows
+    // and is assumed independent of the rotation parameters; only strain and
+    // stress transformation operators are differentiated.
     std::array<Mat6, 3> tangent_rotation_derivatives(
         const Vec3&                position_reference,
         const Mat3&                additional_rotation,
         const std::array<Mat3, 3>& additional_rotation_derivatives,
-        Precision*                 state
+        const Precision*           old_state,
+        Precision*                 new_state
     ) const;
 
     // Report material, region and optional orientation through the logger and a

--- a/tests/test_nonlinear_state_manager.cpp
+++ b/tests/test_nonlinear_state_manager.cpp
@@ -75,7 +75,7 @@ struct TestElement final : model::ElementInterface {
     }
 };
 
-TEST(NonlinearStateManager, ResetsCommitsAndRestoresMaterialStateBinding) {
+TEST(NonlinearStateManager, SeparatesResetsAndCommitsMaterialState) {
     model::Model model;
     model._data = std::make_shared<model::ModelData>();
     model._data->elements.resize(1);
@@ -92,42 +92,60 @@ TEST(NonlinearStateManager, ResetsCommitsAndRestoresMaterialStateBinding) {
     model._data->elements[0] = element;
     model._data->initialize_element_enumeration();
 
-    auto previous_state = std::make_shared<model::Field>(
-        "PREVIOUS_STATE", model::FieldDomain::ELEMENT_MP, 4, 1);
-    model._data->material_state = previous_state;
+    auto enumerated_state_old = model._data->material_state_old;
+    auto enumerated_state_new = model._data->material_state_new;
+
+    model::Field::Ptr committed_state;
+    model::Field::Ptr trial_state;
 
     {
         loadcase::tools::NonlinearStateManager state(model);
 
-        ASSERT_NE(model._data->material_state, nullptr);
-        EXPECT_EQ(model._data->material_state->domain, model::FieldDomain::ELEMENT_MP);
-        EXPECT_EQ(model._data->material_state->rows, 4);
-        EXPECT_EQ(model._data->material_state->components, 3);
+        ASSERT_NE(model._data->material_state_old, nullptr);
+        ASSERT_NE(model._data->material_state_new, nullptr);
+        EXPECT_NE(model._data->material_state_old, model._data->material_state_new);
+        EXPECT_EQ(model._data->material_state_old, enumerated_state_old);
+        EXPECT_EQ(model._data->material_state_new, enumerated_state_new);
+        EXPECT_EQ(model._data->material_state_old->domain, model::FieldDomain::ELEMENT_MP);
+        EXPECT_EQ(model._data->material_state_old->rows, 4);
+        EXPECT_EQ(model._data->material_state_old->components, 3);
 
         for (Index row = 0; row < 4; ++row) {
-            EXPECT_EQ((*model._data->material_state)(row, 0), Precision(1));
-            EXPECT_EQ((*model._data->material_state)(row, 1), Precision(2));
-            EXPECT_EQ((*model._data->material_state)(row, 2), Precision(3));
+            EXPECT_EQ((*model._data->material_state_old)(row, 0), Precision(1));
+            EXPECT_EQ((*model._data->material_state_old)(row, 1), Precision(2));
+            EXPECT_EQ((*model._data->material_state_old)(row, 2), Precision(3));
+            EXPECT_EQ((*model._data->material_state_new)(row, 0), Precision(1));
+            EXPECT_EQ((*model._data->material_state_new)(row, 1), Precision(2));
+            EXPECT_EQ((*model._data->material_state_new)(row, 2), Precision(3));
         }
 
         const Index row = element->mp_index(1, 0);
-        Precision* material_state = &(*model._data->material_state)(row, 0);
-        EXPECT_EQ(material_state[1], Precision(2));
+        const Precision* old_state = &(*model._data->material_state_old)(row, 0);
+        Precision*       new_state = &(*model._data->material_state_new)(row, 0);
+        EXPECT_EQ(old_state[1], Precision(2));
+        EXPECT_EQ(new_state[1], Precision(2));
 
-        material_state[1] = Precision(99);
+        new_state[1] = Precision(99);
+        EXPECT_EQ(old_state[1], Precision(2));
         state.reset_material_state();
-        EXPECT_EQ((*model._data->material_state)(row, 1), Precision(2));
+        EXPECT_EQ((*model._data->material_state_new)(row, 1), Precision(2));
 
-        (*model._data->material_state)(row, 1) = Precision(7);
+        (*model._data->material_state_new)(row, 1) = Precision(7);
         state.commit_material_state();
-        EXPECT_EQ((*model._data->material_state)(row, 1), Precision(7));
+        EXPECT_EQ((*model._data->material_state_old)(row, 1), Precision(7));
+        EXPECT_EQ((*model._data->material_state_new)(row, 1), Precision(7));
 
-        (*model._data->material_state)(row, 1) = Precision(42);
+        (*model._data->material_state_new)(row, 1) = Precision(42);
         state.reset_material_state();
-        EXPECT_EQ((*model._data->material_state)(row, 1), Precision(7));
+        EXPECT_EQ((*model._data->material_state_old)(row, 1), Precision(7));
+        EXPECT_EQ((*model._data->material_state_new)(row, 1), Precision(7));
+
+        committed_state = model._data->material_state_old;
+        trial_state     = model._data->material_state_new;
     }
 
-    EXPECT_EQ(model._data->material_state, previous_state);
+    EXPECT_EQ(model._data->material_state_old, committed_state);
+    EXPECT_EQ(model._data->material_state_new, trial_state);
 }
 
 TEST(NonlinearStateManager, KeepsEnumeratedStateForStatelessMaterials) {
@@ -146,15 +164,19 @@ TEST(NonlinearStateManager, KeepsEnumeratedStateForStatelessMaterials) {
     model._data->elements[0] = element;
     model._data->initialize_element_enumeration();
 
-    auto enumerated_state = model._data->material_state;
-    ASSERT_NE(enumerated_state, nullptr);
+    auto enumerated_state_old = model._data->material_state_old;
+    auto enumerated_state_new = model._data->material_state_new;
+    ASSERT_NE(enumerated_state_old, nullptr);
+    ASSERT_NE(enumerated_state_new, nullptr);
 
     {
         loadcase::tools::NonlinearStateManager state(model);
-        EXPECT_EQ(model._data->material_state, enumerated_state);
+        EXPECT_EQ(model._data->material_state_old, enumerated_state_old);
+        EXPECT_EQ(model._data->material_state_new, enumerated_state_new);
     }
 
-    EXPECT_EQ(model._data->material_state, enumerated_state);
+    EXPECT_EQ(model._data->material_state_old, enumerated_state_old);
+    EXPECT_EQ(model._data->material_state_new, enumerated_state_new);
 }
 
 } // namespace

--- a/tests/test_reader.cpp
+++ b/tests/test_reader.cpp
@@ -106,7 +106,9 @@ TEST(Materials_Orthotropic, TransverseShellShearUsesXzThenYz) {
     ShellMaterialStrainLinearized strain;
     ShellMaterialStressCauchy     stress;
     Mat5                          tangent;
-    ortho.evaluate(strain, nullptr, stress, tangent);
+    Precision old_state = Precision(0);
+    Precision new_state = Precision(0);
+    ortho.evaluate(strain, &old_state, &new_state, stress, tangent);
 
     const Mat2 shear = tangent.template block<2, 2>(3, 3);
 


### PR DESCRIPTION
## Summary

- pass immutable old-state and mutable new-state pointers through every constitutive evaluation
- keep exactly two model-wide material-state buffers and swap them on commit
- propagate the state contract through truss, solid and shell evaluation paths
- remove in-place rollback workarounds from auxiliary constitutive evaluations

## Verification

- static consistency checks completed
- git diff --check passed
- builds and tests not run, per repository instructions