### PR TITLE
Fix *EQUATION token validation

### DIFF
--- a/src/io/reader/commands/register_equation.cpp
+++ b/src/io/reader/commands/register_equation.cpp
@@ -123,8 +123,8 @@ void register_equation(fem::io::dsl::Registry& registry, model::Model& model) {
 
                         std::istringstream dof_stream        (data[i + 1]);
                         std::istringstream coefficient_stream(data[i + 2]);
-                        dof_stream         >> dof         >> std::ws;
-                        coefficient_stream >> coefficient >> std::ws;
+                        dof_stream         >> dof;
+                        coefficient_stream >> coefficient;
 
                         logging::error(!dof_stream.fail() && dof_stream.eof() && dof >= 1 && dof <= 6,
                             "EQUATION: DOF must be an integer in [1,6]");

--- a/src/io/reader/commands/register_equation.cpp
+++ b/src/io/reader/commands/register_equation.cpp
@@ -126,6 +126,11 @@ void register_equation(fem::io::dsl::Registry& registry, model::Model& model) {
                         dof_stream         >> dof;
                         coefficient_stream >> coefficient;
 
+                        // Consume trailing whitespace only while unread characters remain.
+                        // Calling std::ws after numeric extraction already reached EOF sets failbit.
+                        if (!dof_stream.eof())         dof_stream         >> std::ws;
+                        if (!coefficient_stream.eof()) coefficient_stream >> std::ws;
+
                         logging::error(!dof_stream.fail() && dof_stream.eof() && dof >= 1 && dof <= 6,
                             "EQUATION: DOF must be an integer in [1,6]");
                         logging::error(!coefficient_stream.fail() && coefficient_stream.eof() && std::isfinite(coefficient),


### PR DESCRIPTION
Fixes #47.

Removes trailing `std::ws` consumption when validating `*EQUATION` DOF and coefficient tokens. The line parser already strips whitespace, so `std::ws` at EOF sets `failbit` and rejects valid numeric tokens.

Testing: pending manual verification.