### PR TITLE
Generalize system DOF matrices

### DIFF
--- a/src/core/types_eig.h
+++ b/src/core/types_eig.h
@@ -103,8 +103,8 @@ using BooleanMatrix = Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic>;
 
 using Dofs         = Eigen::Matrix<bool, 1, 6>;
 using ElDofs       = Dofs;
-using SystemDofs   = Eigen::Matrix<bool, Eigen::Dynamic, 6, Eigen::RowMajor>;
-using SystemDofIds = Eigen::Matrix<int, Eigen::Dynamic, 6, Eigen::RowMajor>;
+using SystemDofs   = Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+using SystemDofIds = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
 // ============================================================================
 // Integration field types

--- a/src/mattools/numerate_dofs.cpp
+++ b/src/mattools/numerate_dofs.cpp
@@ -24,11 +24,11 @@ namespace fem { namespace mattools {
  * @return SystemDofIds The matrix of numerated DOF IDs.
  */
 SystemDofIds numerate_dofs(const SystemDofs& systemDofs) {
-    SystemDofIds dofIds(systemDofs.rows(), 6);
+    SystemDofIds dofIds(systemDofs.rows(), systemDofs.cols());
     int idCounter = 0;
 
     for (int i = 0; i < systemDofs.rows(); ++i) {
-        for (int j = 0; j < 6; ++j) {
+        for (int j = 0; j < systemDofs.cols(); ++j) {
             if (systemDofs(i, j)) {
                 dofIds(i, j) = idCounter++;
             } else {

--- a/tests/test_mattools.cpp
+++ b/tests/test_mattools.cpp
@@ -1,0 +1,33 @@
+#include "../src/mattools/numerate_dofs.h"
+
+#include <gtest/gtest.h>
+
+using namespace fem;
+
+TEST(MattoolsNumerateDofs, PreservesDynamicColumnCount) {
+    SystemDofs scalar(4, 1);
+    scalar << true, false, true, true;
+
+    const auto scalar_ids = mattools::numerate_dofs(scalar);
+
+    ASSERT_EQ(scalar_ids.rows(), 4);
+    ASSERT_EQ(scalar_ids.cols(), 1);
+    EXPECT_EQ(scalar_ids(0, 0), 0);
+    EXPECT_EQ(scalar_ids(1, 0), -1);
+    EXPECT_EQ(scalar_ids(2, 0), 1);
+    EXPECT_EQ(scalar_ids(3, 0), 2);
+
+    SystemDofs structural(2, 6);
+    structural.fill(false);
+    structural(0, 0) = true;
+    structural(0, 5) = true;
+    structural(1, 2) = true;
+
+    const auto structural_ids = mattools::numerate_dofs(structural);
+
+    ASSERT_EQ(structural_ids.rows(), 2);
+    ASSERT_EQ(structural_ids.cols(), 6);
+    EXPECT_EQ(structural_ids(0, 0), 0);
+    EXPECT_EQ(structural_ids(0, 5), 1);
+    EXPECT_EQ(structural_ids(1, 2), 2);
+}


### PR DESCRIPTION
## Summary
- make `SystemDofs` and `SystemDofIds` dynamically sized in the component dimension
- make `numerate_dofs()` preserve and iterate the input column count instead of assuming six components
- add regression coverage for both scalar `Nx1` and existing structural `Nx6` layouts

## Scope
This is intentionally infrastructure-only. It introduces no thermal DOF indexing, boundary-condition refactor, parser changes, or solver behavior changes.