### PR TITLE
Rename structural DOF index matrix

### DIFF
--- a/src/loadcase/linear_buckling.cpp
+++ b/src/loadcase/linear_buckling.cpp
@@ -188,7 +188,7 @@ void LinearBuckling::run() {
 
     // (1) Unconstrained DOF index (node x 6 -> active dof id or -1)
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
     );
 

--- a/src/loadcase/linear_eigenfreq.cpp
+++ b/src/loadcase/linear_eigenfreq.cpp
@@ -229,7 +229,7 @@ void LinearEigenfrequency::run() {
 
     // (1) Unconstrained system DOF indices (node x 6 -> active dof id or -1)
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
     );
 

--- a/src/loadcase/linear_harmonic.cpp
+++ b/src/loadcase/linear_harmonic.cpp
@@ -134,7 +134,7 @@ void LinearHarmonic::run() {
     model->step_begin();
 
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix");
 
     auto groups = Timer::measure(

--- a/src/loadcase/linear_static.cpp
+++ b/src/loadcase/linear_static.cpp
@@ -40,7 +40,7 @@ void LinearStatic::run() {
     model->step_begin();
 
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix");
 
     auto global_load_mat = Timer::measure(

--- a/src/loadcase/linear_static_topo.cpp
+++ b/src/loadcase/linear_static_topo.cpp
@@ -49,7 +49,7 @@ void LinearStaticTopo::run() {
     model->step_begin();
 
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
     );
 

--- a/src/loadcase/linear_transient.cpp
+++ b/src/loadcase/linear_transient.cpp
@@ -34,7 +34,7 @@ void Transient::run() {
 
     // (1) Unconstrained DOF index
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
     );
 

--- a/src/loadcase/nonlinear_static.cpp
+++ b/src/loadcase/nonlinear_static.cpp
@@ -178,7 +178,7 @@ void NonlinearStatic::run() {
     tools::NonlinearStateManager nonlinear_state(*model);
 
     auto active_dof_idx_mat = Timer::measure(
-        [&]() { return model->build_unconstrained_index_matrix(); },
+        [&]() { return model->build_structural_dof_index_matrix(); },
         "generating active_dof_idx_mat index matrix"
     );
 

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -176,7 +176,7 @@ struct Model {
     // collect prescribed loads and constraints, and assemble structural tangent,
     // geometric, mass and internal-force contributions in global coordinates.
     // Optional stiffness-scaling fields act per element.
-    SystemDofIds build_unconstrained_index_matrix();
+    SystemDofIds build_structural_dof_index_matrix();
     Field build_load_matrix(
         std::vector<std::string> load_sets = {},
         Precision time = 0);

--- a/src/model/model_build.cpp
+++ b/src/model/model_build.cpp
@@ -229,7 +229,7 @@ void Model::build_shell_element_normals(Precision equalize_angle_degrees) {
  *
  * @return Node-by-six matrix of global unconstrained system DOF identifiers.
  */
-SystemDofIds Model::build_unconstrained_index_matrix() {
+SystemDofIds Model::build_structural_dof_index_matrix() {
     logging::error(_data->positions != nullptr,
         "Model: POSITION field is not initialized");
 


### PR DESCRIPTION
## Summary
- rename `build_unconstrained_index_matrix()` to `build_structural_dof_index_matrix()`
- update all structural load-case call sites

## Scope
Pure naming change. No DOF indexing behavior, thermal functionality, assembly logic, or solver behavior is changed.