### PR TITLE
Add thermal DOF index matrix

### DIFF
--- a/src/model/model.h
+++ b/src/model/model.h
@@ -177,6 +177,7 @@ struct Model {
     // geometric, mass and internal-force contributions in global coordinates.
     // Optional stiffness-scaling fields act per element.
     SystemDofIds build_structural_dof_index_matrix();
+    SystemDofIds build_thermal_dof_index_matrix();
     Field build_load_matrix(
         std::vector<std::string> load_sets = {},
         Precision time = 0);

--- a/src/model/model_build_thermal.cpp
+++ b/src/model/model_build_thermal.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file model_build_thermal.cpp
+ * @brief Implements thermal system construction helpers.
+ *
+ * @author Finn Eggers
+ * @date 06.09.2026
+ */
+
+#include "../mattools/numerate_dofs.h"
+#include "element/element_thermal.h"
+#include "model.h"
+
+namespace fem::model {
+
+/**
+ * Enumerates the scalar temperature DOFs required by thermal elements.
+ *
+ * Every node referenced by at least one ThermalElement receives exactly one
+ * active temperature component. Nodes referenced only by non-thermal elements
+ * remain inactive. The resulting mask is converted to contiguous zero-based
+ * system indices.
+ *
+ * @return Node-by-one matrix of global thermal system DOF identifiers.
+ */
+SystemDofIds Model::build_thermal_dof_index_matrix() {
+    logging::error(_data->positions != nullptr,
+        "Model: POSITION field is not initialized");
+
+    SystemDofs mask{_data->positions->rows, 1};
+    mask.fill(false);
+
+    for (const auto& element : _data->elements) {
+        if (element == nullptr || element->as<ThermalElement>() == nullptr) continue;
+
+        for (ID local_node = 0; local_node < element->n_nodes(); ++local_node) {
+            mask(element->nodes()[local_node], 0) = true;
+        }
+    }
+
+    return mattools::numerate_dofs(mask);
+}
+
+} // namespace fem::model

--- a/tests/test_model_thermal.cpp
+++ b/tests/test_model_thermal.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file test_model_thermal.cpp
+ * @brief Tests model-level thermal system helpers.
+ */
+
+#include "../src/model/model.h"
+#include "../src/model/solid/c3d8.h"
+#include "../src/model/truss/truss.h"
+
+#include <gtest/gtest.h>
+
+using namespace fem;
+
+TEST(ModelThermalDofs, ActivatesOnlyThermalElementNodes) {
+    model::Model model;
+
+    model.set_node(0, 0.0, 0.0, 0.0);
+    model.set_node(1, 1.0, 0.0, 0.0);
+    model.set_node(2, 1.0, 1.0, 0.0);
+    model.set_node(3, 0.0, 1.0, 0.0);
+    model.set_node(4, 0.0, 0.0, 1.0);
+    model.set_node(5, 1.0, 0.0, 1.0);
+    model.set_node(6, 1.0, 1.0, 1.0);
+    model.set_node(7, 0.0, 1.0, 1.0);
+    model.set_node(8, 2.0, 0.0, 0.0);
+    model.set_node(9, 3.0, 0.0, 0.0);
+
+    model.set_element<model::C3D8>(0, 0, 1, 2, 3, 4, 5, 6, 7);
+    model.set_element<model::T3>(1, 8, 9);
+    model.compile();
+
+    const SystemDofIds ids = model.build_thermal_dof_index_matrix();
+
+    ASSERT_EQ(ids.rows(), 10);
+    ASSERT_EQ(ids.cols(), 1);
+
+    for (Index node = 0; node < 8; ++node) {
+        EXPECT_EQ(ids(node, 0), node);
+    }
+
+    EXPECT_EQ(ids(8, 0), -1);
+    EXPECT_EQ(ids(9, 0), -1);
+}


### PR DESCRIPTION
## Summary
- add `Model::build_thermal_dof_index_matrix()`
- assign one scalar temperature DOF to nodes referenced by `ThermalElement`s
- keep nodes referenced only by structural elements inactive in the thermal system
- add regression coverage with a thermal C3D8 and a structural-only T3

## Scope
This PR only introduces thermal DOF enumeration. It does not add conductivity assembly, thermal loads, boundary-condition collection, or a thermal load case.