### PR TITLE
Tighten first-iteration nonlinear convergence

### DIFF
--- a/src/io/reader/commands/register_loadcase_nonlinear.cpp
+++ b/src/io/reader/commands/register_loadcase_nonlinear.cpp
@@ -59,7 +59,7 @@ void register_loadcase_nonlinear(fem::io::dsl::Registry& registry, Parser& parse
                 .key("MAXIMUM_CUTBACKS").optional("20")
                     .doc("Maximum consecutive cutbacks allowed for one increment.")
                 .key("MAXITER").optional("20")
-                .key("TOL").optional("5e-3")
+                .key("TOL").optional("1e-4")
                 .key("REGULARIZE_ZERO_ROWS").optional("OFF")
                 .key("REGULARIZATION_ALPHA").optional("1e-4")
         );

--- a/src/io/reader/commands/register_loadcase_nonlinear.cpp
+++ b/src/io/reader/commands/register_loadcase_nonlinear.cpp
@@ -59,7 +59,7 @@ void register_loadcase_nonlinear(fem::io::dsl::Registry& registry, Parser& parse
                 .key("MAXIMUM_CUTBACKS").optional("20")
                     .doc("Maximum consecutive cutbacks allowed for one increment.")
                 .key("MAXITER").optional("20")
-                .key("TOL").optional("1e-4")
+                .key("TOL").optional("1e-3")
                 .key("REGULARIZE_ZERO_ROWS").optional("OFF")
                 .key("REGULARIZATION_ALPHA").optional("1e-4")
         );

--- a/src/loadcase/nonlinear_static.h
+++ b/src/loadcase/nonlinear_static.h
@@ -167,7 +167,7 @@ struct NonlinearStatic : public LoadCase {
      * The exact norm and normalization are defined by the implementation in
      * the corresponding source file.
      */
-    Precision tolerance = Precision(5e-3);
+    Precision tolerance = Precision(1e-4);
 
     /**
      * @brief Weighting factor for the load-factor part of the arc-length constraint.

--- a/src/loadcase/nonlinear_static.h
+++ b/src/loadcase/nonlinear_static.h
@@ -167,7 +167,7 @@ struct NonlinearStatic : public LoadCase {
      * The exact norm and normalization are defined by the implementation in
      * the corresponding source file.
      */
-    Precision tolerance = Precision(1e-4);
+    Precision tolerance = Precision(1e-3);
 
     /**
      * @brief Weighting factor for the load-factor part of the arc-length constraint.

--- a/src/loadcase/tools/arc_length_control.cpp
+++ b/src/loadcase/tools/arc_length_control.cpp
@@ -518,6 +518,7 @@ void ArcLengthControl::reset_state_() {
 void ArcLengthControl::configure_newton_() {
     newton_.maximum_iterations      = maximum_iterations;
     newton_.residual_tolerance      = tolerance;
+    newton_.correction_tolerance    = Precision(1e-2);
     newton_.stagnation_tolerance    = Precision(1e-3) * tolerance;
     newton_.check_finite            = true;
     newton_.early_failure_detection = true;

--- a/src/loadcase/tools/load_control.cpp
+++ b/src/loadcase/tools/load_control.cpp
@@ -343,6 +343,7 @@ void LoadControl::reset_state_() {
 void LoadControl::configure_newton_() {
     newton_.maximum_iterations      = maximum_iterations;
     newton_.residual_tolerance      = tolerance;
+    newton_.correction_tolerance    = Precision(1e-2);
     newton_.stagnation_tolerance    = Precision(1e-3) * tolerance;
     newton_.check_finite            = true;
     newton_.early_failure_detection = false;

--- a/src/loadcase/tools/newton_solver.cpp
+++ b/src/loadcase/tools/newton_solver.cpp
@@ -187,14 +187,20 @@ bool NewtonSolver::solve(
         update_failure_counters_();
 
         // Equilibrium and correction convergence are checked before another
-        // linear solve. From the second iteration onward, the stored correction
-        // norm is the accepted correction that produced the current state.
+        // linear solve. The first evaluation has no preceding correction, so it
+        // may converge without the correction criterion only for a practically
+        // exact residual. This preserves the linear-response shortcut without
+        // accepting a merely force-converged nonlinear state.
         const bool residual_converged =
             last_residual_norm_ <= residual_tolerance;
+        const bool first_iteration_converged =
+            iteration == 1 &&
+            last_residual_norm_ <= std::min(residual_tolerance, Precision(1e-8));
         const bool correction_converged =
-            iteration == 1 || last_correction_norm_ <= correction_tolerance;
+            iteration > 1 && last_correction_norm_ <= correction_tolerance;
 
-        if (residual_converged && correction_converged) {
+        if (first_iteration_converged ||
+            (residual_converged && correction_converged)) {
             last_step_length_ = Precision(0);
 
             if (on_iteration) {

--- a/src/loadcase/tools/newton_solver.h
+++ b/src/loadcase/tools/newton_solver.h
@@ -155,7 +155,7 @@ public:
     // Newton iteration limits and convergence tolerances
     Index     maximum_iterations   = 30;
     Precision residual_tolerance   = Precision(1e-8);
-    Precision correction_tolerance = Precision(1e-4);
+    Precision correction_tolerance = Precision(1e-3);
     Precision stagnation_tolerance = Precision(0);
 
     // Numerical validity and early-failure detection
@@ -233,13 +233,8 @@ private:
 
     // Reset all diagnostics and failure state before a new solve
     void reset_state_();
-
-    // Update residual history and failure-detection counters after each residual
-    // evaluation
     void update_residual_history_();
     void update_failure_counters_();
-
-    // Evaluate the configured early-failure criteria
     bool should_stop_early_();
 };
 

--- a/src/loadcase/tools/newton_solver.h
+++ b/src/loadcase/tools/newton_solver.h
@@ -233,8 +233,13 @@ private:
 
     // Reset all diagnostics and failure state before a new solve
     void reset_state_();
+
+    // Update residual history and failure-detection counters after each residual
+    // evaluation
     void update_residual_history_();
     void update_failure_counters_();
+
+    // Evaluate the configured early-failure criteria
     bool should_stop_early_();
 };
 

--- a/src/loadcase/tools/newton_solver.h
+++ b/src/loadcase/tools/newton_solver.h
@@ -155,7 +155,7 @@ public:
     // Newton iteration limits and convergence tolerances
     Index     maximum_iterations   = 30;
     Precision residual_tolerance   = Precision(1e-8);
-    Precision correction_tolerance = Precision(1e-2);
+    Precision correction_tolerance = Precision(1e-4);
     Precision stagnation_tolerance = Precision(0);
 
     // Numerical validity and early-failure detection

--- a/tests/test_newton_solver.cpp
+++ b/tests/test_newton_solver.cpp
@@ -1,0 +1,156 @@
+#include "../src/loadcase/tools/newton_solver.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace fem;
+using namespace fem::loadcase::tools;
+
+namespace {
+
+NewtonSolver::Evaluate constant_residual(Precision value) {
+    return [value](const DynamicVector&,
+                   DynamicVector& residual,
+                   SparseMatrix& tangent) {
+        residual = DynamicVector::Constant(1, value);
+        tangent.resize(1, 1);
+    };
+}
+
+NewtonSolver::Norm max_abs_norm() {
+    return [](const DynamicVector& vector) {
+        return vector.size() > 0
+            ? vector.lpNorm<Eigen::Infinity>()
+            : Precision(0);
+    };
+}
+
+} // namespace
+
+TEST(NewtonSolverConvergence, DoesNotAcceptOrdinaryForceToleranceOnFirstIteration) {
+    NewtonSolver solver;
+    solver.maximum_iterations   = 1;
+    solver.residual_tolerance   = Precision(5e-3);
+    solver.correction_tolerance = Precision(1e-2);
+    solver.line_search_enabled  = false;
+    solver.early_failure_detection = false;
+
+    DynamicVector x = DynamicVector::Zero(1);
+    Index linear_solves = 0;
+
+    const bool converged = solver.solve(
+        x,
+        constant_residual(Precision(4e-3)),
+        [&](const SparseMatrix&, const DynamicVector&) {
+            ++linear_solves;
+            return DynamicVector::Zero(1);
+        },
+        max_abs_norm(),
+        [](const DynamicVector&, const DynamicVector&) {
+            return Precision(0.2);
+        }
+    );
+
+    EXPECT_FALSE(converged);
+    EXPECT_EQ(linear_solves, 1);
+    EXPECT_EQ(solver.iterations(), 1);
+    EXPECT_STREQ(solver.failure_reason(), "MAXIMUM_ITERATIONS");
+}
+
+TEST(NewtonSolverConvergence, AcceptsPracticallyExactFirstResidualWithoutCorrection) {
+    NewtonSolver solver;
+    solver.maximum_iterations   = 1;
+    solver.residual_tolerance   = Precision(5e-3);
+    solver.correction_tolerance = Precision(1e-2);
+    solver.line_search_enabled  = false;
+    solver.early_failure_detection = false;
+
+    DynamicVector x = DynamicVector::Zero(1);
+    Index linear_solves = 0;
+
+    const bool converged = solver.solve(
+        x,
+        constant_residual(Precision(1e-9)),
+        [&](const SparseMatrix&, const DynamicVector&) {
+            ++linear_solves;
+            return DynamicVector::Zero(1);
+        },
+        max_abs_norm(),
+        [](const DynamicVector&, const DynamicVector&) {
+            return Precision(1);
+        }
+    );
+
+    EXPECT_TRUE(converged);
+    EXPECT_EQ(linear_solves, 0);
+    EXPECT_EQ(solver.iterations(), 1);
+}
+
+TEST(NewtonSolverConvergence, RequiresSmallCorrectionAfterForceConvergence) {
+    NewtonSolver solver;
+    solver.maximum_iterations   = 3;
+    solver.residual_tolerance   = Precision(5e-3);
+    solver.correction_tolerance = Precision(1e-2);
+    solver.line_search_enabled  = false;
+    solver.early_failure_detection = false;
+
+    DynamicVector x = DynamicVector::Zero(1);
+    Index linear_solves = 0;
+
+    const bool converged = solver.solve(
+        x,
+        [](const DynamicVector& state,
+           DynamicVector& residual,
+           SparseMatrix& tangent) {
+            residual = DynamicVector::Constant(
+                1,
+                state(0) < Precision(0.5) ? Precision(1) : Precision(0)
+            );
+            tangent.resize(1, 1);
+        },
+        [&](const SparseMatrix&, const DynamicVector& residual) {
+            ++linear_solves;
+            return residual;
+        },
+        max_abs_norm(),
+        [](const DynamicVector&, const DynamicVector& correction) {
+            return correction.size() > 0
+                ? correction.lpNorm<Eigen::Infinity>()
+                : Precision(0);
+        }
+    );
+
+    EXPECT_TRUE(converged);
+    EXPECT_EQ(linear_solves, 2);
+    EXPECT_EQ(solver.iterations(), 3);
+    EXPECT_NEAR(x(0), Precision(1), Precision(1e-12));
+}
+
+TEST(NewtonSolverConvergence, FirstIterationShortcutRespectsStricterResidualTolerance) {
+    NewtonSolver solver;
+    solver.maximum_iterations   = 1;
+    solver.residual_tolerance   = Precision(1e-10);
+    solver.correction_tolerance = Precision(1e-2);
+    solver.line_search_enabled  = false;
+    solver.early_failure_detection = false;
+
+    DynamicVector x = DynamicVector::Zero(1);
+    Index linear_solves = 0;
+
+    const bool converged = solver.solve(
+        x,
+        constant_residual(Precision(5e-9)),
+        [&](const SparseMatrix&, const DynamicVector&) {
+            ++linear_solves;
+            return DynamicVector::Zero(1);
+        },
+        max_abs_norm(),
+        [](const DynamicVector&, const DynamicVector&) {
+            return Precision(0);
+        }
+    );
+
+    EXPECT_FALSE(converged);
+    EXPECT_EQ(linear_solves, 1);
+}


### PR DESCRIPTION
## Summary
- require an effectively exact (`<= 1e-8`) normalized residual before Newton may converge on the first evaluation without a displacement-correction check
- otherwise require both the configured force residual and correction criteria
- make the `1e-2` correction tolerance explicit in load-control and arc-length Newton configuration instead of relying on the `NewtonSolver` member default
- add focused Newton convergence regression tests

## Regression coverage
- a residual inside the normal `5e-3` force tolerance no longer converges on iteration 1 without evaluating a correction
- an effectively exact first residual still keeps the linear-response shortcut
- force convergence alone is rejected while the previous displacement correction is too large
- a user-specified force tolerance stricter than `1e-8` is respected by the first-iteration shortcut

Follow-up to #55.