### PR TITLE
Tighten nonlinear convergence tolerances

### DIFF
--- a/src/io/reader/commands/register_loadcase_nonlinear.cpp
+++ b/src/io/reader/commands/register_loadcase_nonlinear.cpp
@@ -59,7 +59,7 @@ void register_loadcase_nonlinear(fem::io::dsl::Registry& registry, Parser& parse
                 .key("MAXIMUM_CUTBACKS").optional("20")
                     .doc("Maximum consecutive cutbacks allowed for one increment.")
                 .key("MAXITER").optional("20")
-                .key("TOL").optional("5e-3")
+                .key("TOL").optional("1e-4")
                 .key("REGULARIZE_ZERO_ROWS").optional("OFF")
                 .key("REGULARIZATION_ALPHA").optional("1e-4")
         );

--- a/src/loadcase/nonlinear_static.h
+++ b/src/loadcase/nonlinear_static.h
@@ -167,7 +167,7 @@ struct NonlinearStatic : public LoadCase {
      * The exact norm and normalization are defined by the implementation in
      * the corresponding source file.
      */
-    Precision tolerance = Precision(5e-3);
+    Precision tolerance = Precision(1e-4);
 
     /**
      * @brief Weighting factor for the load-factor part of the arc-length constraint.

--- a/src/loadcase/tools/newton_solver.h
+++ b/src/loadcase/tools/newton_solver.h
@@ -155,7 +155,7 @@ public:
     // Newton iteration limits and convergence tolerances
     Index     maximum_iterations   = 30;
     Precision residual_tolerance   = Precision(1e-8);
-    Precision correction_tolerance = Precision(1e-2);
+    Precision correction_tolerance = Precision(1e-4);
     Precision stagnation_tolerance = Precision(0);
 
     // Numerical validity and early-failure detection


### PR DESCRIPTION
## Summary
- tighten the default relative force tolerance from `5e-3` to `1e-4`
- tighten the default relative displacement-correction tolerance from `1e-2` to `1e-4`
- keep the native `*NONLINEAR` parser default consistent with the loadcase default

Only the three relevant `src` files are changed. No tests, examples, or documentation are touched.