### PR TITLE
Add integration-point extrapolation for solid recovery

### DIFF
--- a/src/math/extrapolate.cpp
+++ b/src/math/extrapolate.cpp
@@ -1,0 +1,122 @@
+/**
+ * @file extrapolate.cpp
+ * @brief Implements polynomial extrapolation between points in natural coordinates.
+ *
+ * @author Finn Eggers
+ * @date 07.09.2026
+ */
+
+#include "extrapolate.h"
+
+#include "../core/logging.h"
+
+#include <Eigen/Cholesky>
+
+namespace fem::math {
+
+/**
+ * Builds a linear operator that reconstructs a polynomial field from source
+ * values and evaluates that field at target points.
+ *
+ * For the selected basis functions `F_j`, the source matrix is
+ *
+ *     A_ij = F_j(r_i, s_i, t_i).
+ *
+ * The polynomial coefficients are obtained by the normal equations
+ *
+ *     (A^T A) a = A^T q_source.
+ *
+ * Evaluating the same basis at the target points gives a matrix `B`, so the
+ * complete source-to-target operator is
+ *
+ *     E = B (A^T A)^-1 A^T,
+ *
+ * and `q_target = E q_source`. All coordinates are natural/reference-space
+ * coordinates; physical element geometry does not enter the recovery operator.
+ *
+ * @param source_points Points carrying the known values, one `(r,s,t)` per row.
+ * @param target_points Points where values shall be reconstructed.
+ * @param basis Polynomial basis defining the reconstruction assumption.
+ * @return Source-to-target extrapolation matrix.
+ */
+RowMatrix extrapolate(const RowMatrix&                          source_points,
+                      const RowMatrix&                          target_points,
+                      std::initializer_list<ExtrapolationBasis> basis) {
+    logging::error(source_points.cols() >= 3,
+        "Extrapolation source points require at least three coordinates");
+    logging::error(target_points.cols() >= 3,
+        "Extrapolation target points require at least three coordinates");
+    logging::error(basis.size() > 0,
+        "Extrapolation requires at least one basis function");
+    logging::error(source_points.rows() >= static_cast<Eigen::Index>(basis.size()),
+        "Extrapolation requires at least as many source points as basis functions (",
+        source_points.rows(), " vs ", basis.size(), ")");
+
+    // Evaluate one selected monomial at one natural-coordinate point.
+    const auto evaluate = [](ExtrapolationBasis function, Precision r, Precision s, Precision t) {
+        switch (function) {
+            case ExtrapolationBasis::F1:    return Precision(1);
+
+            case ExtrapolationBasis::FR:    return r;
+            case ExtrapolationBasis::FS:    return s;
+            case ExtrapolationBasis::FT:    return t;
+
+            case ExtrapolationBasis::FRR:   return r * r;
+            case ExtrapolationBasis::FSS:   return s * s;
+            case ExtrapolationBasis::FTT:   return t * t;
+
+            case ExtrapolationBasis::FRS:   return r * s;
+            case ExtrapolationBasis::FRT:   return r * t;
+            case ExtrapolationBasis::FST:   return s * t;
+            case ExtrapolationBasis::FRST:  return r * s * t;
+
+            case ExtrapolationBasis::FRRS:  return r * r * s;
+            case ExtrapolationBasis::FRRT:  return r * r * t;
+            case ExtrapolationBasis::FSSR:  return s * s * r;
+            case ExtrapolationBasis::FSST:  return s * s * t;
+            case ExtrapolationBasis::FTTR:  return t * t * r;
+            case ExtrapolationBasis::FTTS:  return t * t * s;
+
+            case ExtrapolationBasis::FRRST: return r * r * s * t;
+            case ExtrapolationBasis::FRSST: return r * s * s * t;
+            case ExtrapolationBasis::FRSTT: return r * s * t * t;
+        }
+
+        return Precision(0);
+    };
+
+    const Eigen::Index n_source = source_points.rows();
+    const Eigen::Index n_target = target_points.rows();
+    const Eigen::Index n_basis  = static_cast<Eigen::Index>(basis.size());
+
+    RowMatrix A(n_source, n_basis);
+    RowMatrix B(n_target, n_basis);
+
+    // Assemble the polynomial evaluation matrices at source and target points.
+    Eigen::Index j = 0;
+    for (const auto function : basis) {
+        for (Eigen::Index i = 0; i < n_source; ++i)
+            A(i, j) = evaluate(function, source_points(i, 0), source_points(i, 1), source_points(i, 2));
+
+        for (Eigen::Index i = 0; i < n_target; ++i)
+            B(i, j) = evaluate(function, target_points(i, 0), target_points(i, 1), target_points(i, 2));
+
+        ++j;
+    }
+
+    // Solve the normal system once for the complete source-to-coefficient map.
+    const DynamicMatrix At     = A.transpose();
+    const DynamicMatrix normal = At * A;
+
+    Eigen::LDLT<DynamicMatrix> solver(normal);
+    logging::error(solver.info() == Eigen::Success,
+        "Extrapolation normal-system factorization failed");
+
+    const DynamicMatrix reconstruction = solver.solve(At);
+    logging::error(solver.info() == Eigen::Success && reconstruction.allFinite(),
+        "Extrapolation normal-system solution failed");
+
+    return RowMatrix(B * reconstruction);
+}
+
+} // namespace fem::math

--- a/src/math/extrapolate.cpp
+++ b/src/math/extrapolate.cpp
@@ -55,31 +55,41 @@ RowMatrix extrapolate(const RowMatrix&                          source_points,
     // Evaluate one selected monomial at one natural-coordinate point.
     const auto evaluate = [](ExtrapolationBasis function, Precision r, Precision s, Precision t) {
         switch (function) {
-            case ExtrapolationBasis::F1:    return Precision(1);
+            case ExtrapolationBasis::F1:      return Precision(1);
 
-            case ExtrapolationBasis::FR:    return r;
-            case ExtrapolationBasis::FS:    return s;
-            case ExtrapolationBasis::FT:    return t;
+            case ExtrapolationBasis::FR:      return r;
+            case ExtrapolationBasis::FS:      return s;
+            case ExtrapolationBasis::FT:      return t;
 
-            case ExtrapolationBasis::FRR:   return r * r;
-            case ExtrapolationBasis::FSS:   return s * s;
-            case ExtrapolationBasis::FTT:   return t * t;
+            case ExtrapolationBasis::FRR:     return r * r;
+            case ExtrapolationBasis::FSS:     return s * s;
+            case ExtrapolationBasis::FTT:     return t * t;
 
-            case ExtrapolationBasis::FRS:   return r * s;
-            case ExtrapolationBasis::FRT:   return r * t;
-            case ExtrapolationBasis::FST:   return s * t;
-            case ExtrapolationBasis::FRST:  return r * s * t;
+            case ExtrapolationBasis::FRS:     return r * s;
+            case ExtrapolationBasis::FRT:     return r * t;
+            case ExtrapolationBasis::FST:     return s * t;
+            case ExtrapolationBasis::FRST:    return r * s * t;
 
-            case ExtrapolationBasis::FRRS:  return r * r * s;
-            case ExtrapolationBasis::FRRT:  return r * r * t;
-            case ExtrapolationBasis::FSSR:  return s * s * r;
-            case ExtrapolationBasis::FSST:  return s * s * t;
-            case ExtrapolationBasis::FTTR:  return t * t * r;
-            case ExtrapolationBasis::FTTS:  return t * t * s;
+            case ExtrapolationBasis::FRRS:    return r * r * s;
+            case ExtrapolationBasis::FRRT:    return r * r * t;
+            case ExtrapolationBasis::FSSR:    return s * s * r;
+            case ExtrapolationBasis::FSST:    return s * s * t;
+            case ExtrapolationBasis::FTTR:    return t * t * r;
+            case ExtrapolationBasis::FTTS:    return t * t * s;
 
-            case ExtrapolationBasis::FRRST: return r * r * s * t;
-            case ExtrapolationBasis::FRSST: return r * s * s * t;
-            case ExtrapolationBasis::FRSTT: return r * s * t * t;
+            case ExtrapolationBasis::FRRSS:   return r * r * s * s;
+            case ExtrapolationBasis::FRRTT:   return r * r * t * t;
+            case ExtrapolationBasis::FSSTT:   return s * s * t * t;
+
+            case ExtrapolationBasis::FRRST:   return r * r * s * t;
+            case ExtrapolationBasis::FRSST:   return r * s * s * t;
+            case ExtrapolationBasis::FRSTT:   return r * s * t * t;
+
+            case ExtrapolationBasis::FRRSST:  return r * r * s * s * t;
+            case ExtrapolationBasis::FRRSTT:  return r * r * s * t * t;
+            case ExtrapolationBasis::FRSSTT:  return r * s * s * t * t;
+
+            case ExtrapolationBasis::FRRSSTT: return r * r * s * s * t * t;
         }
 
         return Precision(0);

--- a/src/math/extrapolate.h
+++ b/src/math/extrapolate.h
@@ -1,0 +1,60 @@
+/**
+ * @file extrapolate.h
+ * @brief Declares polynomial extrapolation between points in natural coordinates.
+ *
+ * The module builds a linear recovery operator from values known at source
+ * points to arbitrary target points. A caller explicitly selects the polynomial
+ * basis used for the reconstruction; element topology and quadrature remain
+ * responsibilities of the calling formulation.
+ *
+ * @author Finn Eggers
+ * @date 07.09.2026
+ */
+
+#pragma once
+
+#include "../core/types_eig.h"
+
+#include <initializer_list>
+
+namespace fem::math {
+
+/**
+ * @brief Polynomial basis functions available for reference-space recovery.
+ *
+ * The symbols use the natural coordinates `(r, s, t)`. Higher-order entries are
+ * simple monomials and may be combined freely by the caller.
+ */
+enum class ExtrapolationBasis {
+    F1,
+
+    FR,
+    FS,
+    FT,
+
+    FRR,
+    FSS,
+    FTT,
+
+    FRS,
+    FRT,
+    FST,
+    FRST,
+
+    FRRS,
+    FRRT,
+    FSSR,
+    FSST,
+    FTTR,
+    FTTS,
+
+    FRRST,
+    FRSST,
+    FRSTT,
+};
+
+RowMatrix extrapolate(const RowMatrix&                              source_points,
+                      const RowMatrix&                              target_points,
+                      std::initializer_list<ExtrapolationBasis>     basis);
+
+} // namespace fem::math

--- a/src/math/extrapolate.h
+++ b/src/math/extrapolate.h
@@ -48,13 +48,23 @@ enum class ExtrapolationBasis {
     FTTR,
     FTTS,
 
+    FRRSS,
+    FRRTT,
+    FSSTT,
+
     FRRST,
     FRSST,
     FRSTT,
+
+    FRRSST,
+    FRRSTT,
+    FRSSTT,
+
+    FRRSSTT,
 };
 
-RowMatrix extrapolate(const RowMatrix&                              source_points,
-                      const RowMatrix&                              target_points,
-                      std::initializer_list<ExtrapolationBasis>     basis);
+RowMatrix extrapolate(const RowMatrix&                          source_points,
+                      const RowMatrix&                          target_points,
+                      std::initializer_list<ExtrapolationBasis> basis);
 
 } // namespace fem::math

--- a/src/math/quadrature.h
+++ b/src/math/quadrature.h
@@ -201,16 +201,6 @@ public:
         return res;
     }
 
-    /**
-     * @brief Extrapolates point-wise values back to nodal values (currently unimplemented).
-     */
-    template<int M, int N>
-    StaticVector<N> extrapolate(const StaticMatrix<M, N>& values) const {
-        (void) values;
-        runtime_assert(M == count(), "Number of values must match number of quadrature points");
-        return StaticVector<N>::Zero();
-    }
-
     /// Returns the `n`-th quadrature point.
     Point get_point(ID n) const;
 

--- a/src/model/solid/c3d10.h
+++ b/src/model/solid/c3d10.h
@@ -26,5 +26,16 @@ struct C3D10 : public SolidElement<10>{
 
     const math::quadrature::Quadrature& integration_scheme() const override;
     const math::quadrature::Quadrature& integration_scheme_stiffness() const override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FR,
+             math::ExtrapolationBasis::FS,
+             math::ExtrapolationBasis::FT});
+        return matrix;
+    }
 };
 } }

--- a/src/model/solid/c3d13.h
+++ b/src/model/solid/c3d13.h
@@ -25,5 +25,22 @@ struct C3D13 : public SolidElement<13>{
     StaticMatrix<13, 1> shape_function(Precision r, Precision s, Precision t) override;
     StaticMatrix<13, 3> shape_derivative(Precision r, Precision s, Precision t) override;
     StaticMatrix<13, 3> node_coords_local() override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FR,
+             math::ExtrapolationBasis::FS,
+             math::ExtrapolationBasis::FT,
+             math::ExtrapolationBasis::FRR,
+             math::ExtrapolationBasis::FSS,
+             math::ExtrapolationBasis::FTT,
+             math::ExtrapolationBasis::FRS,
+             math::ExtrapolationBasis::FRT,
+             math::ExtrapolationBasis::FST});
+        return matrix;
+    }
 };
 } }

--- a/src/model/solid/c3d15.h
+++ b/src/model/solid/c3d15.h
@@ -25,5 +25,21 @@ struct C3D15 : public SolidElement<15>{
     StaticMatrix<15, 1> shape_function(Precision r, Precision s, Precision t) override;
     StaticMatrix<15, 3> shape_derivative(Precision r, Precision s, Precision t) override;
     StaticMatrix<15, 3> node_coords_local() override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FR,
+             math::ExtrapolationBasis::FS,
+             math::ExtrapolationBasis::FT,
+             math::ExtrapolationBasis::FRT,
+             math::ExtrapolationBasis::FST,
+             math::ExtrapolationBasis::FTT,
+             math::ExtrapolationBasis::FTTR,
+             math::ExtrapolationBasis::FTTS});
+        return matrix;
+    }
 };
 } }

--- a/src/model/solid/c3d20.h
+++ b/src/model/solid/c3d20.h
@@ -25,5 +25,32 @@ struct C3D20 : public SolidElement<20>{
     StaticMatrix<20, 1> shape_function(Precision r, Precision s, Precision t) override;
     StaticMatrix<20, 3> shape_derivative(Precision r, Precision s, Precision t) override;
     StaticMatrix<20, 3> node_coords_local() override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FR,
+             math::ExtrapolationBasis::FS,
+             math::ExtrapolationBasis::FT,
+             math::ExtrapolationBasis::FRS,
+             math::ExtrapolationBasis::FRT,
+             math::ExtrapolationBasis::FST,
+             math::ExtrapolationBasis::FRST,
+             math::ExtrapolationBasis::FRR,
+             math::ExtrapolationBasis::FSS,
+             math::ExtrapolationBasis::FTT,
+             math::ExtrapolationBasis::FRRS,
+             math::ExtrapolationBasis::FRRT,
+             math::ExtrapolationBasis::FSSR,
+             math::ExtrapolationBasis::FSST,
+             math::ExtrapolationBasis::FTTR,
+             math::ExtrapolationBasis::FTTS,
+             math::ExtrapolationBasis::FRRST,
+             math::ExtrapolationBasis::FRSST,
+             math::ExtrapolationBasis::FRSTT});
+        return matrix;
+    }
 };
 } }

--- a/src/model/solid/c3d20.h
+++ b/src/model/solid/c3d20.h
@@ -34,22 +34,29 @@ protected:
              math::ExtrapolationBasis::FR,
              math::ExtrapolationBasis::FS,
              math::ExtrapolationBasis::FT,
+             math::ExtrapolationBasis::FRR,
+             math::ExtrapolationBasis::FSS,
+             math::ExtrapolationBasis::FTT,
              math::ExtrapolationBasis::FRS,
              math::ExtrapolationBasis::FRT,
              math::ExtrapolationBasis::FST,
              math::ExtrapolationBasis::FRST,
-             math::ExtrapolationBasis::FRR,
-             math::ExtrapolationBasis::FSS,
-             math::ExtrapolationBasis::FTT,
              math::ExtrapolationBasis::FRRS,
              math::ExtrapolationBasis::FRRT,
              math::ExtrapolationBasis::FSSR,
              math::ExtrapolationBasis::FSST,
              math::ExtrapolationBasis::FTTR,
              math::ExtrapolationBasis::FTTS,
+             math::ExtrapolationBasis::FRRSS,
+             math::ExtrapolationBasis::FRRTT,
+             math::ExtrapolationBasis::FSSTT,
              math::ExtrapolationBasis::FRRST,
              math::ExtrapolationBasis::FRSST,
-             math::ExtrapolationBasis::FRSTT});
+             math::ExtrapolationBasis::FRSTT,
+             math::ExtrapolationBasis::FRRSST,
+             math::ExtrapolationBasis::FRRSTT,
+             math::ExtrapolationBasis::FRSSTT,
+             math::ExtrapolationBasis::FRRSSTT});
         return matrix;
     }
 };

--- a/src/model/solid/c3d20r.h
+++ b/src/model/solid/c3d20r.h
@@ -26,5 +26,20 @@ struct C3D20R : public SolidElement<20>{
     StaticMatrix<20, 1> shape_function(Precision r, Precision s, Precision t) override;
     StaticMatrix<20, 3> shape_derivative(Precision r, Precision s, Precision t) override;
     StaticMatrix<20, 3> node_coords_local() override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FR,
+             math::ExtrapolationBasis::FS,
+             math::ExtrapolationBasis::FT,
+             math::ExtrapolationBasis::FRS,
+             math::ExtrapolationBasis::FRT,
+             math::ExtrapolationBasis::FST,
+             math::ExtrapolationBasis::FRST});
+        return matrix;
+    }
 };
 } }

--- a/src/model/solid/c3d4.h
+++ b/src/model/solid/c3d4.h
@@ -95,5 +95,13 @@ struct C3D4 : public SolidElement<4> {
     const math::quadrature::Quadrature& integration_scheme() const override;
 
     SurfacePtr surface(ID surface_id) override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1});
+        return matrix;
+    }
 };
 } } // namespace fem::model

--- a/src/model/solid/c3d6.h
+++ b/src/model/solid/c3d6.h
@@ -25,5 +25,14 @@ struct C3D6 : public SolidElement<6>{
     StaticMatrix<6, 3> node_coords_local() override;
 
     std::string type_name() const override { return "C3D6"; }
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FT});
+        return matrix;
+    }
 };
 } }

--- a/src/model/solid/c3d8.h
+++ b/src/model/solid/c3d8.h
@@ -53,6 +53,21 @@ struct C3D8 : public SolidElement<8> {
     // Boundary topology and element integration rule
     SurfacePtr surface(ID surface_id) override;
     const math::quadrature::Quadrature& integration_scheme() const override;
+
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1,
+             math::ExtrapolationBasis::FR,
+             math::ExtrapolationBasis::FS,
+             math::ExtrapolationBasis::FT,
+             math::ExtrapolationBasis::FRS,
+             math::ExtrapolationBasis::FRT,
+             math::ExtrapolationBasis::FST,
+             math::ExtrapolationBasis::FRST});
+        return matrix;
+    }
 };
 
 } // namespace model

--- a/src/model/solid/c3d8r.h
+++ b/src/model/solid/c3d8r.h
@@ -63,6 +63,14 @@ public:
         const Field& displacement
     ) override;
 
+protected:
+    const RowMatrix& extrapolation_matrix() override {
+        static const RowMatrix matrix = math::extrapolate(
+            this->stress_strain_ip_rst(), this->node_coords_local(),
+            {math::ExtrapolationBasis::F1});
+        return matrix;
+    }
+
 private:
     // Hourglass modes, reference gradients and material scaling
     HourglassModes primitive_hourglass_modes();

--- a/src/model/solid/element_solid.h
+++ b/src/model/solid/element_solid.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "../../math/extrapolate.h"
 #include "../../math/interpolate.h"
 #include "../../material/strain/volume_strain_green_lagrange.h"
 #include "../../material/strain/volume_strain_linearized.h"
@@ -57,6 +58,10 @@ struct SolidElement : StructuralElement, ThermalElement{
 
 protected:
     friend math::quadrature::Quadrature;
+
+    // Topology-specific reference-space recovery from constitutive integration
+    // points to element nodes. Concrete solids cache this constant matrix.
+    virtual const RowMatrix& extrapolation_matrix() = 0;
 
 public:
     SolidElement(ID elem_id, std::array<ID, N> node_ids)
@@ -224,9 +229,9 @@ public:
 
     void apply_tload(Field& node_loads, const Field& node_temp, Precision ref_temp) override;
 
-    // Stress/strain recovery is state-neutral. Requested output coordinates may
-    // reuse committed history from the nearest constitutive integration point;
-    // nonlinear PK2 stress is pushed forward to Cauchy stress for user output.
+    // Stress/strain recovery is state-neutral. Constitutive response is evaluated
+    // only at material integration points; nodal output is extrapolated from the
+    // corresponding integration-point values in natural coordinates.
     void compute_stress_strain(
         Field*           strain,
         Field*           stress,

--- a/src/model/solid/element_solid_compute.ipp
+++ b/src/model/solid/element_solid_compute.ipp
@@ -65,24 +65,23 @@ void SolidElement<N>::evaluate_material(Precision                        r,
 }
 
 /**
- * Recovers solid strain and Cauchy stress at requested natural coordinates.
+ * Recovers solid strain and Cauchy stress from constitutive integration points.
+ *
+ * Material response is evaluated only at the stiffness quadrature points, where
+ * the corresponding committed material-state row is defined. Integration-point
+ * output is copied directly. Nodal output is obtained by applying the concrete
+ * element's constant reference-space extrapolation matrix to the IP values.
  *
  * Linearized recovery uses the reference-configuration small-strain B matrix.
- * Nonlinear recovery derives Green-Lagrange strain from the deformation
- * gradient, evaluates PK2 stress and pushes it forward to Cauchy stress for
- * output. Because requested coordinates may be nodal extrapolation points
- * rather than constitutive integration points, each location reuses the
- * committed state row of the nearest stiffness quadrature point in natural
- * coordinates.
- *
- * Recovery is strictly state-neutral: constitutive history may be read but no
- * target trial state is supplied. Degenerate output mappings are skipped in the
- * linearized path. At least one optional output field must be supplied.
+ * Nonlinear recovery evaluates Green-Lagrange strain at each material point,
+ * obtains PK2 stress from committed history and pushes it forward to Cauchy
+ * stress. Recovery is state-neutral and never creates nodal constitutive states.
  *
  * @param strain Optional output field for linearized or Green-Lagrange strain.
  * @param stress Optional output field for Cauchy stress.
  * @param displacement Global nodal displacement field.
- * @param rst Natural output coordinates, one point per row.
+ * @param rst Requested natural coordinates. Solids support their material
+ *            integration points and their element nodes.
  * @param offset First output row belonging to this element.
  * @param use_green_lagrange_nl Select nonlinear Total-Lagrangian recovery.
  */
@@ -98,50 +97,39 @@ void SolidElement<N>::compute_stress_strain(Field*           strain,
     logging::error(rst.cols() >= 3,
         "SolidElement: stress/strain evaluation coordinates require at least 3 columns");
 
+    const auto&     scheme      = this->integration_scheme_stiffness();
+    const RowMatrix ip_rst      = this->stress_strain_ip_rst();
+    const bool      output_at_ip =
+        rst.rows() == ip_rst.rows() && rst.leftCols(3).isApprox(ip_rst);
+    const bool output_at_nodes = rst.rows() == static_cast<Eigen::Index>(N);
+
+    logging::error(output_at_ip || output_at_nodes,
+        "SolidElement: stress/strain output must use integration points or element nodes");
+
     const auto reference_coords       = this->node_coords_reference();
     const auto local_displacement     = this->nodal_data<3>(displacement);
     const auto local_disp_mat         = StaticMatrix<3, N>(local_displacement.transpose());
-    const auto local_displacement_vec = Eigen::Map<const StaticVector<3 * N>>(local_disp_mat.data(), 3 * N);
-    const auto current_coords         = reference_coords + local_displacement;
-    const auto& state_scheme          = this->integration_scheme_stiffness();
+    const auto local_displacement_vec =
+        Eigen::Map<const StaticVector<3 * N>>(local_disp_mat.data(), 3 * N);
+    const auto current_coords = reference_coords + local_displacement;
 
-    for (Eigen::Index n = 0; n < rst.rows(); ++n) {
-        const Precision r   = rst(n, 0);
-        const Precision s   = rst(n, 1);
-        const Precision t   = rst(n, 2);
-        const Index     row = static_cast<Index>(offset + n);
+    RowMatrix ip_strain = RowMatrix::Zero(scheme.count(), n_strain);
+    RowMatrix ip_stress = RowMatrix::Zero(scheme.count(), n_strain);
 
-        // Output coordinates may be nodal rather than constitutive integration
-        // points. Reuse the committed history row of the nearest material point.
-        Index state_ip = 0;
-        auto  state_point = state_scheme.get_point(0);
-        Precision state_distance =
-            (r - state_point.r) * (r - state_point.r)
-            + (s - state_point.s) * (s - state_point.s)
-            + (t - state_point.t) * (t - state_point.t);
+    // Evaluate kinematics and material response only where constitutive state
+    // actually exists: at the element's stiffness integration points.
+    for (Index ip = 0; ip < scheme.count(); ++ip) {
+        const auto point = scheme.get_point(ip);
 
-        for (Index ip = 1; ip < state_scheme.count(); ++ip) {
-            state_point = state_scheme.get_point(ip);
-            const Precision distance =
-                (r - state_point.r) * (r - state_point.r)
-                + (s - state_point.s) * (s - state_point.s)
-                + (t - state_point.t) * (t - state_point.t);
-
-            if (distance < state_distance) {
-                state_ip       = ip;
-                state_distance = distance;
-            }
-        }
-
-        const Index      state_row = this->mp_index(state_ip);
+        const Index      state_row = this->mp_index(ip);
         const Precision* old_state = &(*this->_model_data->material_state_old)(state_row, 0);
 
-        // Linearized recovery evaluates Cauchy stress directly from the
-        // infinitesimal reference-configuration strain field.
+        // Linear recovery evaluates the small-strain field and Cauchy stress at
+        // the material point without producing a new constitutive state.
         if (!use_green_lagrange_nl) {
             Precision det;
-            const StaticMatrix<n_strain, D * N> B =
-                this->strain_displacements(reference_coords, r, s, t, det, false);
+            const StaticMatrix<n_strain, D * N> B = this->strain_displacements(
+                reference_coords, point.r, point.s, point.t, det, false);
 
             if (det <= Precision(0) || !std::isfinite(det)) {
                 continue;
@@ -151,29 +139,66 @@ void SolidElement<N>::compute_stress_strain(Field*           strain,
             const VolumeStrainLinearized global_strain(global_strain_voigt);
             VolumeStressCauchy           global_stress;
             Mat6                         global_tangent;
-            evaluate_material(r, s, t, global_strain, old_state, nullptr, global_stress, global_tangent);
+            evaluate_material(
+                point.r, point.s, point.t,
+                global_strain, old_state, nullptr,
+                global_stress, global_tangent);
 
-            for (Dim j = 0; j < n_strain; ++j) {
-                if (strain) (*strain)(row, j) = global_strain.voigt()(j);
-                if (stress) (*stress)(row, j) = global_stress.voigt()(j);
+            for (Dim component = 0; component < n_strain; ++component) {
+                ip_strain(ip, component) = global_strain.voigt()(component);
+                ip_stress(ip, component) = global_stress.voigt()(component);
             }
             continue;
         }
 
-        // Nonlinear recovery needs only the state-neutral PK2 stress. The
-        // optional-tangent path deliberately avoids building dS/dE here.
-        const Mat3 F = this->deformation_gradient(reference_coords, current_coords, r, s, t);
+        // Nonlinear recovery evaluates the same Green-Lagrange/PK2 pair used by
+        // the Total-Lagrangian formulation and pushes PK2 stress to Cauchy stress.
+        const Mat3 F = this->deformation_gradient(
+            reference_coords, current_coords, point.r, point.s, point.t);
         const VolumeStrainGreenLagrange green_lagrange =
             VolumeStrainGreenLagrange::from_deformation_gradient(F);
 
         VolumeStressPK2 second_pk;
-        evaluate_material(r, s, t, green_lagrange, old_state, nullptr, second_pk, nullptr);
+        evaluate_material(
+            point.r, point.s, point.t,
+            green_lagrange, old_state, nullptr,
+            second_pk, nullptr);
 
         const VolumeStressCauchy cauchy = second_pk.to_cauchy(F);
 
-        for (Dim j = 0; j < n_strain; ++j) {
-            if (strain) (*strain)(row, j) = green_lagrange.voigt()(j);
-            if (stress) (*stress)(row, j) = cauchy.voigt()(j);
+        for (Dim component = 0; component < n_strain; ++component) {
+            ip_strain(ip, component) = green_lagrange.voigt()(component);
+            ip_stress(ip, component) = cauchy.voigt()(component);
+        }
+    }
+
+    // Integration-point output is the constitutive result itself and must not be
+    // projected through a recovery basis.
+    if (output_at_ip) {
+        for (Eigen::Index n = 0; n < rst.rows(); ++n) {
+            const Index row = static_cast<Index>(offset + n);
+            for (Dim component = 0; component < n_strain; ++component) {
+                if (strain) (*strain)(row, component) = ip_strain(n, component);
+                if (stress) (*stress)(row, component) = ip_stress(n, component);
+            }
+        }
+        return;
+    }
+
+    // Nodal values are reconstructed from the integration-point samples in
+    // natural coordinates using the topology-specific constant operator.
+    const RowMatrix& E = this->extrapolation_matrix();
+    logging::error(E.rows() == rst.rows() && E.cols() == scheme.count(),
+        "SolidElement: invalid extrapolation matrix for element ", this->elem_id);
+
+    const RowMatrix nodal_strain = E * ip_strain;
+    const RowMatrix nodal_stress = E * ip_stress;
+
+    for (Eigen::Index n = 0; n < rst.rows(); ++n) {
+        const Index row = static_cast<Index>(offset + n);
+        for (Dim component = 0; component < n_strain; ++component) {
+            if (strain) (*strain)(row, component) = nodal_strain(n, component);
+            if (stress) (*stress)(row, component) = nodal_stress(n, component);
         }
     }
 }


### PR DESCRIPTION
## Summary

- add a central `math::extrapolate(...)` utility for polynomial recovery in natural coordinates
- define per-solid static extrapolation operators from constitutive integration points to element nodes
- evaluate solid stress/strain only at actual material integration points
- recover nodal solid results by applying the cached extrapolation matrix
- remove the old unimplemented `Quadrature::extrapolate()` stub
- keep shell recovery unchanged

## Motivation

Solid nodal recovery currently re-evaluates kinematics and constitutive response directly at nodal natural coordinates and reuses the nearest material-point state. This is problematic for degenerated topologies such as the C3D5 representation through a collapsed C3D8, where direct evaluation at the apex can encounter a singular geometry mapping.

The new path keeps constitutive evaluation at the actual integration points and performs only algebraic IP-to-node recovery afterwards:

`q_node = E q_ip`

The operator `E` is built once per solid topology in reference space and cached statically.

## Recovery assumptions

- C3D4: constant
- C3D6: constant + through-thickness linear term
- C3D8: trilinear Q1
- C3D8R: constant
- C3D10: linear tetrahedral basis
- C3D13: quadratic least-squares basis
- C3D15: wedge-compatible polynomial basis
- C3D20: full triquadratic Q2 recovery from 27 IPs
- C3D20R: trilinear Q1 recovery from 8 IPs to 20 nodes

The reconstruction uses the normal equations in natural coordinates:

`E = B (A^T A)^-1 A^T`

No physical element distortion enters the extrapolation operator itself.

## Scope

This PR intentionally changes solid result recovery only. Shells, beams and trusses are left unchanged.

## Validation

The changes were reviewed statically for matrix dimensions, basis rank and consistency with the current solid integration schemes. No local build or test run was performed as part of this change.