### PR TITLE
Allow solver selection in Abaqus input

### DIFF
--- a/src/io/reader/commands/register_loadcase_solver.cpp
+++ b/src/io/reader/commands/register_loadcase_solver.cpp
@@ -33,7 +33,7 @@ namespace fem::io::reader::commands {
 
 void register_loadcase_solver(fem::io::dsl::Registry& registry, Parser& parser) {
     registry.command("SOLVER", [&](fem::io::dsl::Command& command) {
-        command.allow_if(fem::io::dsl::Condition::parent_is("LOADCASE"));
+        command.allow_if(fem::io::dsl::Condition::parent_is({"LOADCASE", "STEP"}));
         command.doc(
             "Configure solver options for the active loadcase.\n"
             "\n"
@@ -57,7 +57,7 @@ void register_loadcase_solver(fem::io::dsl::Registry& registry, Parser& parser) 
         command.on_enter([&parser](const fem::io::dsl::Keys& keys) {
             auto* base = parser.active_loadcase();
             logging::error(base != nullptr,
-                "SOLVER must appear inside *LOADCASE");
+                "SOLVER requires an active loadcase and must follow the analysis procedure");
 
             const auto device = keys.raw("DEVICE");
             const auto method = keys.raw("METHOD");

--- a/src/io/reader/parser_abq.cpp
+++ b/src/io/reader/parser_abq.cpp
@@ -100,6 +100,7 @@ void ParserAbq::register_common_commands(io::dsl::Registry& registry) {
     commands::register_spring(registry, model());
     commands::register_equation(registry, model());
     commands::register_coupling(registry, model());
+    commands::register_loadcase_solver(registry, *this);
 
     commands_abq::register_expansion(registry, model());
     commands_abq::register_orientation(registry, model());


### PR DESCRIPTION
## Summary
- register the existing `*SOLVER` command for Abaqus input decks
- allow `*SOLVER` inside Abaqus `*STEP` scopes as well as native `*LOADCASE` scopes
- reuse the existing `DEVICE` / `METHOD` handling without introducing automatic RAM-based solver selection

In Abaqus mode the keyword must follow the analysis procedure card so an active FEMaster load case exists.

Example:
```text
*STEP
*STATIC
*SOLVER, DEVICE=CPU, METHOD=INDIRECT
...
*END STEP
```

Closes #61