### PR TITLE
Fix TIE ADJUST reference geometry initialization

### DIFF
--- a/src/constraints/types/tie.cpp
+++ b/src/constraints/types/tie.cpp
@@ -515,13 +515,22 @@ Equations Tie::get_surface_surface_equations(SystemDofIds& system_nodal_dofs, mo
 }
 
 /**
+ * Applies the optional TIE, ADJUST projection during model initialization.
+ */
+void Tie::adjust_geometry(model::ModelData& model_data) {
+    if (!adjust) return;
+    get_equations(nullptr, model_data);
+}
+
+/**
  * @copydoc Tie::get_equations
  */
-Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& model_data) {
-    logging::error(model_data.positions != nullptr, "positions field not set in model data");
-    if (adjust) {
+Equations Tie::get_equations(SystemDofIds* system_nodal_dofs, model::ModelData& model_data) {
+    logging::error(model_data.positions != nullptr,
+        "positions field not set in model data");
+    if (adjust && system_nodal_dofs == nullptr) {
         logging::error(model_data.positions_reference != nullptr,
-                       "reference positions field not set in model data");
+            "reference positions field not set in model data");
     }
 
     auto&     node_coords = *model_data.positions;
@@ -651,7 +660,7 @@ Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& 
             mapped_pos = l_ptr->local_to_global(best_local(0), node_coords);
         }
 
-        if (adjust) {
+        if (adjust && system_nodal_dofs == nullptr) {
             // TIE, ADJUST changes the model's initial geometry. Keep the active
             // and reference position fields synchronized so the snap is not
             // interpreted later as a physical deformation of the slave side.
@@ -662,12 +671,14 @@ Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& 
             }
         }
 
+        if (system_nodal_dofs == nullptr) continue;
+
         // ---------------------------------------------------------------------
         // Determine active DOFs: slave must have DOF AND all master nodes must have DOF
         // ---------------------------------------------------------------------
         Dofs dofs_mask;
         for (Dim dof_id = 0; dof_id < 6; ++dof_id) {
-            dofs_mask(0, dof_id) = (system_nodal_dofs(id, dof_id) >= 0);
+            dofs_mask(0, dof_id) = ((*system_nodal_dofs)(id, dof_id) >= 0);
         }
 
         DynamicVector nodal_contributions;
@@ -679,7 +690,7 @@ Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& 
             for (ID local_id = 0; local_id < static_cast<ID>(s_ptr->n_nodes); ++local_id) {
                 const ID master_node_id = s_ptr->nodes()[local_id];
                 for (Dim dof_id = 0; dof_id < 6; ++dof_id) {
-                    dofs_mask(0, dof_id) = dofs_mask(0, dof_id) && (system_nodal_dofs(master_node_id, dof_id) >= 0);
+                    dofs_mask(0, dof_id) = dofs_mask(0, dof_id) && ((*system_nodal_dofs)(master_node_id, dof_id) >= 0);
                 }
             }
 
@@ -691,7 +702,7 @@ Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& 
             for (ID local_id = 0; local_id < static_cast<ID>(l_ptr->n_nodes); ++local_id) {
                 const ID master_node_id = l_ptr->nodes()[local_id];
                 for (Dim dof_id = 0; dof_id < 6; ++dof_id) {
-                    dofs_mask(0, dof_id) = dofs_mask(0, dof_id) && (system_nodal_dofs(master_node_id, dof_id) >= 0);
+                    dofs_mask(0, dof_id) = dofs_mask(0, dof_id) && ((*system_nodal_dofs)(master_node_id, dof_id) >= 0);
                 }
             }
 
@@ -743,6 +754,13 @@ Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& 
     }
 
     return equations;
+}
+
+/**
+ * @copydoc Tie::get_equations
+ */
+Equations Tie::get_equations(SystemDofIds& system_nodal_dofs, model::ModelData& model_data) {
+    return get_equations(&system_nodal_dofs, model_data);
 }
 }    // namespace constraint
 }    // namespace fem

--- a/src/constraints/types/tie.h
+++ b/src/constraints/types/tie.h
@@ -44,6 +44,7 @@ class Tie {
 
     Equations get_surface_surface_equations(SystemDofIds& system_nodal_dofs,
                                             model::ModelData& model_data);
+    Equations get_equations(SystemDofIds* system_nodal_dofs, model::ModelData& model_data);
 
 public:
     // -------------------------------------------------------------------------
@@ -82,6 +83,9 @@ public:
         model::SurfaceRegion::Ptr slave,
         Precision max_distance,
         bool do_adjust);
+
+    // Initial geometry adjustment before geometry-derived reference fields are built
+    void adjust_geometry(model::ModelData& model_data);
 
     /**
      * @brief Generates the constraint equations associated with the tie.

--- a/src/io/reader/commands/register_tie.cpp
+++ b/src/io/reader/commands/register_tie.cpp
@@ -7,9 +7,9 @@
  * and stores it directly in ModelData. No Model-side constraint factory or type
  * dispatcher participates in this path.
  *
- * Search distance and optional initial adjustment are retained by the selected
- * tie formulation. Projection, interpolation and constraint-equation assembly
- * use the compiled geometry later when a load case collects constraints.
+ * `TIE, ADJUST` is applied immediately after construction against the compiled
+ * reference geometry. Constraint-equation assembly remains deferred until a
+ * load case collects constraints.
  *
  * @author Finn Eggers
  * @date 19.08.2026
@@ -77,6 +77,8 @@ void register_tie(fem::io::dsl::Registry& registry, model::Model& model) {
             } else {
                 model._data->ties.emplace_back(master_lines, slave_surfaces, distance, adjust);
             }
+
+            model._data->ties.back().adjust_geometry(*model._data);
         });
         command.variant(fem::io::dsl::Variant::make());
     });

--- a/src/io/reader/parser.cpp
+++ b/src/io/reader/parser.cpp
@@ -206,7 +206,13 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
         assembly->execute_children("NORMAL");
     }
 
-    // Complete reference normals before constraints or analyses consume shells.
+    // Apply initial tie adjustments before geometry-derived reference fields are completed.
+    root.execute_children("TIE");
+    for (const auto* assembly : root.children("ASSEMBLY")) {
+        assembly->execute_children("TIE");
+    }
+
+    // Complete reference normals from the final initial geometry.
     model_->build_shell_element_normals();
 
     // ---------------------------------------------------------------------
@@ -228,7 +234,6 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
 
     root.execute_children("RBM");
     root.execute_children("CONNECTOR");
-    root.execute_children("TIE");
     root.execute_children("CONTACT");
     root.execute_children("EQUATION");
 
@@ -247,7 +252,6 @@ void Parser::process_deck(const io::dsl::Deck&                  deck,
 
         assembly->execute_children("RBM");
         assembly->execute_children("CONNECTOR");
-        assembly->execute_children("TIE");
         assembly->execute_children("CONTACT");
         assembly->execute_children("EQUATION");
     }


### PR DESCRIPTION
## Summary

- apply `TIE, ADJUST` once when the parsed tie definition is materialized, immediately after constructing the `Tie`
- reuse the existing closest-point projection path in a geometry-only mode; later constraint collection only generates equations and no longer mutates the reference configuration
- execute `TIE` definitions before automatic shell reference normals are generated so adjusted shell geometry and directors remain consistent
- keep `Model::step_begin()` and the nonlinear load-case lifecycle unchanged, avoiding `POSITION` metadata changes and repeated geometry projection

Fixes #45.

## Validation

Statically reviewed against the current `master`. Per repository guidelines, no build or tests were run.