### PR TITLE
Parallelize model recovery and fixed-DOF reduction

### DIFF
--- a/src/constraints/transformer/constraint_map.cpp
+++ b/src/constraints/transformer/constraint_map.cpp
@@ -13,8 +13,9 @@
  *
  * The explicit partition into master and slave DOFs allows vector recovery and
  * projection to be performed without multiplying by the complete sparse
- * transformation matrix. Matrix reduction still uses `T` directly to construct
- * the congruence transformation
+ * transformation matrix. Matrix reduction extracts the principal master block
+ * directly for selector-only maps and otherwise constructs the general
+ * congruence transformation
  *
  *     K_r = T^T K T.
  *
@@ -168,6 +169,81 @@ DynamicVector ConstraintMap::project(const DynamicVector& full) const {
 // This preserves the virtual work and quadratic-form representation of the
 // original operator in the admissible homogeneous coordinate space.
 SparseMatrix ConstraintMap::reduce_matrix(const SparseMatrix& matrix) const {
+    // A map without slave-to-master coefficients is a pure selector. For the
+    // common fixed-DOF case T only embeds the ordered master coordinates, so
+    // T^T K T is exactly the principal submatrix K(masters, masters).
+    bool ordered_masters = true;
+    for (Index master = 1; master < n_master(); ++master) {
+        if (masters[static_cast<std::size_t>(master - 1)] >=
+            masters[static_cast<std::size_t>(master)]) {
+            ordered_masters = false;
+            break;
+        }
+    }
+
+    if (X.nonZeros() == 0 && ordered_masters) {
+        logging::error(
+            matrix.rows() == static_cast<Eigen::Index>(full_size) &&
+            matrix.cols() == static_cast<Eigen::Index>(full_size),
+            "[ConstraintMap::reduce_matrix] matrix size does not match full constraint space"
+        );
+
+        // Map full-system indices to reduced coordinates. The full_size sentinel
+        // marks constrained/slave rows that must be omitted from the principal block.
+        const Index invalid = full_size;
+        std::vector<Index> full_to_reduced(static_cast<std::size_t>(full_size), invalid);
+        for (Index reduced_dof = 0; reduced_dof < n_master(); ++reduced_dof) {
+            const Index full_dof = masters[static_cast<std::size_t>(reduced_dof)];
+            logging::error(full_dof < full_size,
+                "[ConstraintMap::reduce_matrix] master DOF out of range: ", full_dof);
+            full_to_reduced[static_cast<std::size_t>(full_dof)] = reduced_dof;
+        }
+
+        // Count retained entries per reduced column so Eigen can allocate the
+        // output sparsity exactly before the ordered insertion pass.
+        Eigen::VectorXi nonzeros_per_column = Eigen::VectorXi::Zero(
+            static_cast<Eigen::Index>(n_master())
+        );
+
+        for (Index reduced_col = 0; reduced_col < n_master(); ++reduced_col) {
+            const Index full_col = masters[static_cast<std::size_t>(reduced_col)];
+            int count = 0;
+            for (SparseMatrix::InnerIterator entry(matrix, static_cast<int>(full_col)); entry; ++entry) {
+                const Index full_row = static_cast<Index>(entry.row());
+                if (full_to_reduced[static_cast<std::size_t>(full_row)] != invalid) {
+                    ++count;
+                }
+            }
+            nonzeros_per_column[static_cast<Eigen::Index>(reduced_col)] = count;
+        }
+
+        SparseMatrix reduced(
+            static_cast<Eigen::Index>(n_master()),
+            static_cast<Eigen::Index>(n_master())
+        );
+        reduced.reserve(nonzeros_per_column);
+
+        // The master list is strictly ordered and every source column stores its
+        // row indices in ascending order. The mapped reduced rows are therefore
+        // also inserted monotonically within each output column.
+        for (Index reduced_col = 0; reduced_col < n_master(); ++reduced_col) {
+            const Index full_col = masters[static_cast<std::size_t>(reduced_col)];
+            for (SparseMatrix::InnerIterator entry(matrix, static_cast<int>(full_col)); entry; ++entry) {
+                const Index reduced_row = full_to_reduced[static_cast<std::size_t>(entry.row())];
+                if (reduced_row == invalid) continue;
+
+                reduced.insert(
+                    static_cast<Eigen::Index>(reduced_row),
+                    static_cast<Eigen::Index>(reduced_col)
+                ) = entry.value();
+            }
+        }
+
+        reduced.makeCompressed();
+        return reduced;
+    }
+
+    // General coupled constraints require the complete congruence transform.
     // Work with compressed sparse operands because Eigen's sparse products are
     // sensitive to the storage state of the input matrices. The transformation
     // transpose is materialized once so the left product does not rebuild it

--- a/src/core/timer.cpp
+++ b/src/core/timer.cpp
@@ -12,11 +12,11 @@
 namespace fem {
 
 void Timer::start() {
-    start_time = std::chrono::high_resolution_clock::now();
+    start_time = Clock::now();
 }
 
 void Timer::stop() {
-    end_time = std::chrono::high_resolution_clock::now();
+    end_time = Clock::now();
 }
 
 Time Timer::elapsed() const {

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -63,8 +63,10 @@ public:
     static double measure_time(Func&& func);
 
 private:
-    std::chrono::high_resolution_clock::time_point start_time{};
-    std::chrono::high_resolution_clock::time_point end_time{};
+    using Clock = std::chrono::steady_clock;
+
+    Clock::time_point start_time{};
+    Clock::time_point end_time{};
 };
 
 template<typename Func>

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -29,8 +29,10 @@
 
 #include "../bc/load_collector.h"
 #include "../bc/support_collector.h"
+#include "../core/config.h"
 
 #include <charconv>
+#include <exception>
 #include <iterator>
 #include <string>
 #include <system_error>
@@ -69,26 +71,50 @@ ID parse_local_id(const std::string& source, const char* entity) {
  * Every compiled structural element receives a lifecycle callback. Elements
  * that do not require persistent step data use the default no-op implementation,
  * while formulations such as finite-rotation shells construct their cached
- * reference geometry here.
+ * reference geometry here. Independent element initialization may execute in
+ * parallel because every structural element owns its complete step-local state.
  *
- * Initialization is transactional at model level: if one element throws, the
- * method invokes `step_end()` for the complete model to release every cache that
- * may already have been created, then propagates the original exception.
+ * Initialization remains transactional at model level. Worker exceptions are
+ * captured inside the OpenMP region because C++ exceptions cannot cross an
+ * OpenMP boundary. After all workers have completed, a failed initialization
+ * releases every potentially created element cache through `step_end()` and
+ * rethrows the first captured exception.
  */
 void Model::step_begin() {
-    // Initialize analysis-local state for every compiled structural element
-    try {
-        for (auto& elem : _data->elements) {
-            if (elem) {
-                if (auto* structural = elem->as<StructuralElement>()) {
-                    structural->step_begin();
+    const Index element_count = static_cast<Index>(_data->elements.size());
+    std::exception_ptr failure = nullptr;
+
+    // Initialize independent analysis-local element state in parallel. Each
+    // worker catches its own exception so no exception escapes the OpenMP region.
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static, 1024) num_threads(global_config.max_threads) if(global_config.max_threads > 1)
+#endif
+    for (Index elem_idx = 0; elem_idx < element_count; ++elem_idx) {
+        try {
+            auto& elem = _data->elements[static_cast<std::size_t>(elem_idx)];
+            if (!elem) continue;
+
+            if (auto* structural = elem->as<StructuralElement>()) {
+                structural->step_begin();
+            }
+        } catch (...) {
+            // Preserve the first failure while allowing all workers to reach the
+            // implicit barrier before model-level cleanup is attempted.
+#ifdef _OPENMP
+            #pragma omp critical
+#endif
+            {
+                if (!failure) {
+                    failure = std::current_exception();
                 }
             }
         }
-    } catch (...) {
-        // Release partially initialized state before propagating the failure
+    }
+
+    // Release partially initialized state before propagating a worker failure
+    if (failure) {
         step_end();
-        throw;
+        std::rethrow_exception(failure);
     }
 }
 

--- a/src/model/model_compute.cpp
+++ b/src/model/model_compute.cpp
@@ -8,9 +8,10 @@
  * element-nodal quantities are recovered into global nodal fields through the
  * weighting operation provided by `ModelData`.
  *
- * Nodal stress recovery, shell-face recovery, beam section forces and shear
- * flow may evaluate elements with OpenMP. Eigen and MKL internal threading are
- * temporarily restricted during those loops to avoid nested oversubscription.
+ * Nodal stress recovery, shell-face recovery, shell-resultant recovery, beam
+ * section forces and shear flow may evaluate elements with OpenMP. Eigen and MKL
+ * internal threading are temporarily restricted during those loops to avoid
+ * nested oversubscription.
  *
  * @see Model
  * @see ModelData
@@ -23,6 +24,9 @@
 #include "../core/config.h"
 #include "element/element_structural.h"
 #include "model.h"
+
+#include <exception>
+#include <vector>
 
 #ifdef _OPENMP
     #include <omp.h>
@@ -261,35 +265,115 @@ std::tuple<Field, Field> Model::compute_stress_top_bot(Field& displacement, bool
  * Recovers nodal shell force and moment resultants.
  *
  * Supporting elements accumulate their eight-component resultant convention and
- * one participation count at every connected global node. The model divides the
- * accumulated values by those counts to obtain an arithmetic nodal average;
- * nodes without shell contributions retain zero rows.
+ * one participation count at every connected global node. Parallel element
+ * recovery writes into one private nodal accumulator per OpenMP worker because
+ * adjacent shell elements may share nodes. The worker fields are reduced by
+ * global node and divided by the summed counts to preserve the original
+ * arithmetic nodal average.
  *
  * @param displacement Global nodal displacement field used for recovery.
  * @return Averaged eight-component nodal shell-resultant field.
  */
 Field Model::compute_shell_resultants(Field& displacement) {
-    // Allocate nodal accumulators for resultants and contribution counts
-    const Index node_count = _data->field_rows(FieldDomain::NODE);
-    Field resultants{"SHELL_RESULTANTS", FieldDomain::NODE, node_count, 8};
-    Field count{"SHELL_RESULTANTS_COUNT", FieldDomain::NODE, node_count, 1};
-    resultants.set_zero();
-    count.set_zero();
+    const Index node_count    = _data->field_rows(FieldDomain::NODE);
+    const Index element_count = static_cast<Index>(_data->elements.size());
 
-    // Accumulate formulation-specific shell resultants from structural elements
-    for (auto el : _data->elements) {
-        if (!el) continue;
-        if (auto sel = el->as<StructuralElement>()) {
-            sel->compute_shell_section_forces(resultants, count, displacement);
+#ifdef _OPENMP
+    const int thread_count = global_config.max_threads > 1 ? global_config.max_threads : 1;
+#else
+    const int thread_count = 1;
+#endif
+
+    // Allocate independent nodal accumulators because adjacent shell elements
+    // may write resultants to the same global node.
+    std::vector<Field> thread_resultants;
+    std::vector<Field> thread_counts;
+    thread_resultants.reserve(static_cast<std::size_t>(thread_count));
+    thread_counts.reserve(static_cast<std::size_t>(thread_count));
+
+    for (int thread = 0; thread < thread_count; ++thread) {
+        thread_resultants.emplace_back("SHELL_RESULTANTS_THREAD", FieldDomain::NODE, node_count, 8);
+        thread_counts.emplace_back("SHELL_RESULTANTS_COUNT_THREAD", FieldDomain::NODE, node_count, 1);
+        thread_resultants.back().set_zero();
+        thread_counts.back().set_zero();
+    }
+
+    // Prevent nested Eigen/MKL threading inside the element-parallel recovery loop
+    Eigen::setNbThreads(1);
+#ifdef USE_MKL
+    mkl_set_num_threads(1);
+#endif
+
+    std::exception_ptr failure = nullptr;
+
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static, 1024) num_threads(global_config.max_threads) if(global_config.max_threads > 1)
+#endif
+    // Recover each element into the accumulator owned by its OpenMP worker
+    for (Index elem_idx = 0; elem_idx < element_count; ++elem_idx) {
+        try {
+            int thread = 0;
+#ifdef _OPENMP
+            thread = omp_get_thread_num();
+#endif
+
+            auto el = _data->elements[static_cast<std::size_t>(elem_idx)];
+            if (!el) continue;
+
+            if (auto sel = el->as<StructuralElement>()) {
+                sel->compute_shell_section_forces(
+                    thread_resultants[static_cast<std::size_t>(thread)],
+                    thread_counts[static_cast<std::size_t>(thread)],
+                    displacement
+                );
+            }
+        } catch (...) {
+            // Keep C++ exceptions inside the OpenMP region and propagate the
+            // first failure after all workers reach the implicit barrier.
+#ifdef _OPENMP
+            #pragma omp critical
+#endif
+            {
+                if (!failure) {
+                    failure = std::current_exception();
+                }
+            }
         }
     }
 
-    // Convert accumulated contributions into arithmetic nodal averages
-    for (Index i = 0; i < node_count; ++i) {
-        if (count(i, 0) != Precision(0)) {
-            for (Index j = 0; j < resultants.components; ++j) {
-                resultants(i, j) /= count(i, 0);
+    // Restore the configured linear-algebra thread counts after element recovery
+#ifdef USE_MKL
+    mkl_set_num_threads(global_config.max_threads);
+#endif
+    Eigen::setNbThreads(global_config.max_threads);
+
+    if (failure) {
+        std::rethrow_exception(failure);
+    }
+
+    // Reduce worker-local contributions independently for every global node
+    Field resultants{"SHELL_RESULTANTS", FieldDomain::NODE, node_count, 8};
+    resultants.set_zero();
+
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static, 1024) num_threads(global_config.max_threads) if(global_config.max_threads > 1)
+#endif
+    for (Index node = 0; node < node_count; ++node) {
+        Precision count = Precision(0);
+
+        for (int thread = 0; thread < thread_count; ++thread) {
+            const auto index = static_cast<std::size_t>(thread);
+            count += thread_counts[index](node, 0);
+
+            for (Index component = 0; component < resultants.components; ++component) {
+                resultants(node, component) += thread_resultants[index](node, component);
             }
+        }
+
+        if (count == Precision(0)) continue;
+
+        for (Index component = 0; component < resultants.components; ++component) {
+            resultants(node, component) /= count;
         }
     }
 

--- a/src/model/model_data.cpp
+++ b/src/model/model_data.cpp
@@ -21,6 +21,10 @@
 #include "model_data.h"
 #include "element/element.h"
 
+#include "../core/config.h"
+
+#include <vector>
+
 namespace fem::model {
 
 /**
@@ -247,10 +251,10 @@ Field ModelData::create_field_(const std::string& name,
  * Projects element-nodal values onto unique global nodes by weighted averaging.
  *
  * The compiled element-nodal prefix offsets locate the local rows belonging to
- * each dense element. For every connected global node and component, the method
- * accumulates the element-local value multiplied by the scalar weight of its
- * element. The accumulated field is then divided by the sum of participating
- * weights at that node.
+ * each dense element. A compact node-to-element-row gather map is constructed
+ * for the participating elements and stores each source row together with its
+ * scalar element weight. Global nodes are then independent reduction targets,
+ * so OpenMP partitions the nodal range without atomics or overlapping writes.
  *
  * Elements with zero weight do not participate. Nodes without a contributing
  * element retain the initialized zero row. The operation assumes that every
@@ -295,26 +299,20 @@ Field ModelData::element_nodal_to_nodal(const Field&       element_nodal,
         "ModelData: ELEMENT_NODAL field '", element_nodal.name,
         "' has ", element_nodal.rows, " rows, expected ", expected_rows);
 
-    // Initialize nodal value and weight accumulators for the projection
-    Field nodal{name, FieldDomain::NODE, node_count, element_nodal.components};
-    nodal.set_zero();
-    std::vector<Precision> weight_sum(static_cast<std::size_t>(node_count), Precision(0));
+    // Count participating element-nodal source rows for every global node. The
+    // shifted count layout becomes a CSR-style offset array after prefix summing.
+    std::vector<Index> node_offsets(static_cast<std::size_t>(node_count + 1), Index(0));
 
-    // Accumulate every participating element-local row at its connected global node
     for (Index elem_idx = 0; elem_idx < element_count; ++elem_idx) {
         const auto& element = elements[static_cast<std::size_t>(elem_idx)];
-        if (!element) {
-            continue;
-        }
+        if (!element) continue;
 
         const ID elem_id = element->elem_id;
         logging::error(elem_id >= 0 && static_cast<Index>(elem_id) < element_count,
             "ModelData: element id out of range in element_nodal_to_nodal: ", elem_id);
 
         const Precision weight = element_weights(static_cast<Index>(elem_id), 0);
-        if (weight == Precision(0)) {
-            continue;
-        }
+        if (weight == Precision(0)) continue;
 
         const Index offset      = static_cast<Index>(offsets(static_cast<Index>(elem_id), 0));
         const Index next_offset = static_cast<Index>(offsets(static_cast<Index>(elem_id) + 1, 0));
@@ -324,26 +322,71 @@ Field ModelData::element_nodal_to_nodal(const Field&       element_nodal,
             "ModelData: element nodal offset span does not match node count for element ", elem_id);
 
         for (Index local_node = 0; local_node < static_cast<Index>(element->n_nodes()); ++local_node) {
-            const Index element_row = offset + local_node;
-            const Index node_id     = static_cast<Index>(element->nodes()[local_node]);
-            logging::error(node_id < node_count,
+            const Index node_id = static_cast<Index>(element->nodes()[local_node]);
+            logging::error(node_id >= 0 && node_id < node_count,
                 "ModelData: node id out of range in element_nodal_to_nodal: ", node_id);
-
-            for (Index component = 0; component < element_nodal.components; ++component) {
-                nodal(node_id, component) += weight * element_nodal(element_row, component);
-            }
-            weight_sum[static_cast<std::size_t>(node_id)] += weight;
+            ++node_offsets[static_cast<std::size_t>(node_id + 1)];
         }
     }
 
-    // Normalize accumulated values by the total element weight at each node
+    // Convert nodal contribution counts into half-open gather ranges
     for (Index node = 0; node < node_count; ++node) {
-        const Precision weight = weight_sum[static_cast<std::size_t>(node)];
-        if (weight == Precision(0)) {
-            continue;
+        node_offsets[static_cast<std::size_t>(node + 1)] += node_offsets[static_cast<std::size_t>(node)];
+    }
+
+    const Index contribution_count = node_offsets.back();
+    std::vector<Index>     source_rows   (static_cast<std::size_t>(contribution_count));
+    std::vector<Precision> source_weights(static_cast<std::size_t>(contribution_count));
+    std::vector<Index>     write_offsets = node_offsets;
+
+    // Fill the compact gather map in element order. Each entry identifies one
+    // element-nodal source row and its already resolved scalar element weight.
+    for (Index elem_idx = 0; elem_idx < element_count; ++elem_idx) {
+        const auto& element = elements[static_cast<std::size_t>(elem_idx)];
+        if (!element) continue;
+
+        const ID elem_id = element->elem_id;
+        const Precision weight = element_weights(static_cast<Index>(elem_id), 0);
+        if (weight == Precision(0)) continue;
+
+        const Index offset = static_cast<Index>(offsets(static_cast<Index>(elem_id), 0));
+        for (Index local_node = 0; local_node < static_cast<Index>(element->n_nodes()); ++local_node) {
+            const Index node_id = static_cast<Index>(element->nodes()[local_node]);
+            const Index target  = write_offsets[static_cast<std::size_t>(node_id)]++;
+
+            source_rows   [static_cast<std::size_t>(target)] = offset + local_node;
+            source_weights[static_cast<std::size_t>(target)] = weight;
         }
+    }
+
+    // Gather and normalize each global node independently. OpenMP partitions the
+    // target rows, so no two workers can write the same nodal result entry.
+    Field nodal{name, FieldDomain::NODE, node_count, element_nodal.components};
+    nodal.set_zero();
+
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static, 1024) num_threads(global_config.max_threads) if(global_config.max_threads > 1)
+#endif
+    for (Index node = 0; node < node_count; ++node) {
+        Precision weight_sum = Precision(0);
+        const Index begin = node_offsets[static_cast<std::size_t>(node)];
+        const Index end   = node_offsets[static_cast<std::size_t>(node + 1)];
+
+        for (Index entry = begin; entry < end; ++entry) {
+            const auto index         = static_cast<std::size_t>(entry);
+            const Index source_row   = source_rows[index];
+            const Precision weight   = source_weights[index];
+            weight_sum              += weight;
+
+            for (Index component = 0; component < element_nodal.components; ++component) {
+                nodal(node, component) += weight * element_nodal(source_row, component);
+            }
+        }
+
+        if (weight_sum == Precision(0)) continue;
+
         for (Index component = 0; component < element_nodal.components; ++component) {
-            nodal(node, component) /= weight;
+            nodal(node, component) /= weight_sum;
         }
     }
 


### PR DESCRIPTION
## Summary

- parallelize `Model::step_begin()` across independent structural elements while preserving transactional cleanup and exception propagation
- parallelize shell-resultant recovery with worker-local nodal accumulators followed by a node-parallel reduction
- parallelize `ModelData::element_nodal_to_nodal()` as a gather over disjoint global-node ranges using a compact CSR-style node-to-source-row map
- add a selector fast path for constraint-matrix reduction when `X.nonZeros() == 0`: extract `K(masters, masters)` directly instead of forming `T^T K T` through two general sparse matrix products
- use `std::chrono::steady_clock` for elapsed-time measurements so timer readings are based on a monotonic clock

The fixed-DOF fast path also applies to inhomogeneous prescribed displacements because the affine contribution remains handled by the existing RHS reduction through `u_p`. General coupled constraints retain the existing `T^T K T` implementation unchanged.

## Scope

The changes are limited to model lifecycle/result recovery, fixed-DOF constraint reduction, and the timer clock source. Element formulations, solver backends, output formats, build-system, and CI are unchanged.

## Validation

Reviewed statically against the current implementation. Per project code guidelines, no build or test commands were run as part of this patch.